### PR TITLE
fix: await params so blog posts stop 404ing

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -9,9 +9,9 @@ import { H1, H4, Paragraph } from "~/components/utils/text";
 import { prismicClient } from "~/lib/prismic";
 
 type Props = {
-  params: {
+  params: Promise<{
     slug: string;
-  };
+  }>;
 };
 
 export const metadata: Metadata = {
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
 
 export default async function BlogPost({ params }: Props) {
   const client = prismicClient();
-  const { slug } = params;
+  const { slug } = await params;
 
   if (!slug) notFound();
 


### PR DESCRIPTION
**Every `/blog/<slug>` page has been returning 404 since the Next 16 upgrade.** All six posts are currently dead in production. This is a 3-line fix.

## Cause

Next 15 made `params` a Promise. `src/app/blog/[slug]/page.tsx` destructured it synchronously:

```ts
type Props = {
  params: {           // ← lies: Next passes a Promise
    slug: string;
  };
};

const { slug } = params;   // ← undefined
if (!slug) notFound();     // ← fires on every request
```

So `slug` was `undefined` and the guard on line 26 returned a 404 for every post.

## Why nothing caught it

This is the part worth noting for the rest of the migration. The hand-written `Props` type **asserted** that `params` was a plain object, and TypeScript had no reason to doubt a hand-written annotation. So `tsc --noEmit` passed, `next build` passed, and all six posts 404'd in production.

A green build was never going to catch this. Every route in this app is `ƒ (Dynamic)`, so the build renders nothing — it only type-checks, and the type was the thing that was wrong.

`layout.tsx:21` already does `(await cookies())`, so the async-API migration was done correctly there; this route was just missed. I grepped the rest of `src/app` — this was the only `params` consumer, and there are no `searchParams` consumers.

## Verification

Built and ran a production server against the live Prismic repo:

**Before (on `main`) — all six 404:**
```
/blog/add-dark-mode-to-your-react-application-with-tailwindcss    -> HTTP 404
/blog/building-a-responsive-navbar-with-tailwindcss               -> HTTP 404
/blog/four-ways-of-applying-styles-in-your-react-application      -> HTTP 404
/blog/learn-javascript-closures-the-easy-way                      -> HTTP 404
/blog/presenting-recipe-keeper-...                                -> HTTP 404
/blog/two-sum---the-easiest-leetcode-exercise                     -> HTTP 404
```

**After — all six 200**, and content genuinely renders rather than just returning a status code. Spot-checking `learn-javascript-closures-the-easy-way`: 47KB, `<h1>Learn JavaScript closures the easy way</h1>`, cover image from `images.prismic.io`, and a full rich-text body (35 `<p>`, 3 `<h2>`, 5 `<pre>` code blocks, a `<ul>`).

`tsc --noEmit` and `pnpm build` both exit 0.

## Noticed, not fixed

All posts share the static `metadata` title `"Juan Alvarez | Blog"` — the one already marked `// Mejorar esto` on line 18. Now that posts actually load, that title is what search engines and link previews will pick up, so it may be worth promoting to a `generateMetadata` using the post title. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)