### PR TITLE
docs: replace boilerplate readme with real project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,84 @@
-# Next.js + Tailwind CSS Example
+# juanalvarez.dev
 
-This example shows how to use [Tailwind CSS](https://tailwindcss.com/) [(v2.2)](https://blog.tailwindcss.com/tailwindcss-2-2) with Next.js. It follows the steps outlined in the official [Tailwind docs](https://tailwindcss.com/docs/guides/nextjs).
+My personal site and blog — [juanalvarez.dev](https://juanalvarez.dev). Next.js App Router, content managed in Prismic, deployed on Vercel.
 
-It uses the new [`Just-in-Time Mode`](https://tailwindcss.com/docs/just-in-time-mode) for Tailwind CSS.
+## Stack
 
-## Preview
+| Piece | What it does |
+| --- | --- |
+| [Next.js 16](https://nextjs.org/) (App Router) | Framework. Pages are server components; content is fetched at request time and cached by tag. |
+| [Prismic](https://prismic.io/) | CMS. Drives the homepage slices and every blog post. |
+| [Tailwind CSS](https://tailwindcss.com/) 3 + [`@tailwindcss/typography`](https://github.com/tailwindlabs/tailwindcss-typography) | Styling. The `prose` classes handle blog post body copy. |
+| [Framer Motion](https://www.framer.com/motion/) | Mobile menu transitions. |
+| [Nodemailer](https://nodemailer.com/) | Sends the contact form through Gmail SMTP. |
+| [ImprovMX](https://improvmx.com/) | Email forwarding for the `@juanalvarez.dev` domain — see [Email](#email). |
+| [Cypress](https://www.cypress.io/) | End-to-end tests. |
+| [Vercel](https://vercel.com/) | Hosting. |
 
-Preview the example live on [StackBlitz](http://stackblitz.com/):
+Package manager is **pnpm** (`pnpm@11.17.0`, pinned via `packageManager`). Vercel builds with Corepack enabled — see `vercel.json`.
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/vercel/next.js/tree/canary/examples/with-tailwindcss)
-
-## Deploy your own
-
-Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example):
-
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/next.js/tree/canary/examples/with-tailwindcss&project-name=with-tailwindcss&repository-name=with-tailwindcss)
-
-## How to use
-
-Execute [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app) with [npm](https://docs.npmjs.com/cli/init) or [Yarn](https://yarnpkg.com/lang/en/docs/cli/create/) to bootstrap the example:
+## Getting started
 
 ```bash
-npx create-next-app --example with-tailwindcss with-tailwindcss-app
-# or
-yarn create next-app --example with-tailwindcss with-tailwindcss-app
+pnpm install
+pnpm dev
 ```
 
-Deploy it to the cloud with [Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).
+Then open http://localhost:3000.
+
+You need a `.env` before the app will boot — Prismic is required, the rest depends on what you're touching:
+
+| Variable | Required | What it's for |
+| --- | --- | --- |
+| `API_ENDPOINT` | yes | Prismic repository name. Passed to `prismic.getRepositoryEndpoint()`, so it's the repo **name**, not a full URL. |
+| `MAIL_USER` | contact form only | Gmail account used as the SMTP sender. |
+| `MAIL_PASSWORD` | contact form only | Gmail **app password**, not the account password. |
+| `PRISMIC_WEBHOOK_SECRET` | production only | Shared secret guarding `/api/revalidate`. If unset, the route accepts any request. |
+| `DATABASE_URL` | build only | MySQL connection string for Prisma. Needed because `prisma generate` runs as part of `pnpm build`. |
+
+## Layout
+
+```
+src/
+  app/
+    page.tsx              Homepage — renders Prismic slices
+    blog/                 Post index and [slug] detail page
+    contact/              Contact form page
+    api/mail/             POST — sends the contact form email
+    api/revalidate/       POST — Prismic webhook, busts the "prismic" cache tag
+  components/
+    IndexSlices/          One component per Prismic slice type
+    MobileMenu/           Animated mobile nav
+  lib/
+    prismic.ts            Prismic client factory + preview support
+    db.ts                 Prisma client
+types.generated.ts        Generated from the Prismic custom types — do not edit by hand
+```
+
+### Content
+
+Everything editorial lives in Prismic. The homepage is a slice zone; each slice type maps to a component in `src/components/IndexSlices/`. Blog posts are a `blog_post` custom type, looked up by a `slug` field rather than by Prismic UID.
+
+`types.generated.ts` is produced by [`prismic-ts-codegen`](https://github.com/prismicio/prismic-ts-codegen) from the custom type definitions. Regenerate it after changing a type in Prismic instead of editing it.
+
+Caching: in production the Prismic client tags every fetch with `prismic` and uses `force-cache`. A Prismic webhook pointed at `/api/revalidate` clears that tag on publish. In development it revalidates every 5 seconds instead, so edits show up without a restart.
+
+## Email
+
+Two separate things, easy to confuse:
+
+**Inbound — ImprovMX.** Addresses on the domain (`info@juanalvarez.dev`, etc.) are aliases hosted by [ImprovMX](https://improvmx.com/), which forwards anything sent to them on to my personal Gmail inbox. There's no mailbox on the domain itself; ImprovMX is purely a forwarder, configured through the domain's MX records rather than anything in this repo. Nothing here breaks if it goes down — inbound mail just stops arriving.
+
+**Outbound — Gmail SMTP.** The contact form (`src/app/api/mail/route.ts`) sends through `smtp.gmail.com` authenticated with `MAIL_USER` / `MAIL_PASSWORD`, with the `From` header set to `info@juanalvarez.dev` and `Reply-To` set to whatever the visitor typed. So the domain address on outgoing mail is the ImprovMX alias, but ImprovMX isn't doing the sending — Gmail is.
+
+`MAIL_PASSWORD` must be a Google [app password](https://support.google.com/accounts/answer/185833); a normal account password will fail SMTP auth.
+
+## Scripts
+
+| Command | Does |
+| --- | --- |
+| `pnpm dev` | Dev server |
+| `pnpm build` | `prisma generate`, then `next build` |
+| `pnpm start` | Serve a production build |
+| `pnpm lint` | ESLint (flat config, `eslint.config.mjs`) |
+| `pnpm cypress:open` | Open the Cypress runner |


### PR DESCRIPTION
The README was still the stock `create-next-app` boilerplate — it described the Vercel Tailwind example, linked a StackBlitz demo, and told the reader to run `npx create-next-app --example with-tailwindcss`. Not one line was about this site. This replaces it wholesale.

## What's in it

- **Stack** — Next 16 App Router, Prismic, Tailwind + typography, Framer Motion, Nodemailer, ImprovMX, Cypress, Vercel. Notes that the package manager is pnpm, pinned via `packageManager`, with Corepack enabled in `vercel.json`.
- **Getting started** — install/run, plus every env var the app reads, with the two that are easy to get wrong called out: `API_ENDPOINT` is the Prismic repository **name**, not a URL (it's passed to `getRepositoryEndpoint()`), and `MAIL_PASSWORD` has to be a Google app password or SMTP auth fails.
- **Layout** — annotated tree of `src/`, plus a note that `types.generated.ts` comes from `prismic-ts-codegen` and shouldn't be hand-edited.
- **Content** — homepage is a Prismic slice zone mapping to `src/components/IndexSlices/`; posts are a `blog_post` type looked up by a `slug` field rather than by UID. Documents the caching: production tags fetches with `prismic` and uses `force-cache`, the webhook at `/api/revalidate` clears that tag on publish, dev revalidates every 5s instead.
- **Email** — see below.
- **Scripts** — what each `pnpm` script actually does.

## The email section

Split deliberately into inbound and outbound, because they're two different systems that read like one:

**Inbound is ImprovMX.** Addresses on the domain are aliases that forward to the personal Gmail inbox. There's no mailbox on the domain; it's configured through MX records, nothing in this repo. If it goes down, inbound mail stops arriving and nothing here breaks.

**Outbound is Gmail SMTP.** `src/app/api/mail/route.ts` sends through `smtp.gmail.com` with `From: info@juanalvarez.dev` and `Reply-To` set to the visitor. So the ImprovMX alias appears on outgoing mail, but Gmail is doing the sending — ImprovMX isn't a relay here.

That inbound/outbound split is the one bit I inferred rather than read off the code, so it's worth a sanity check. Everything else in the README is verified against the source.

## Not in scope

Writing this surfaced three unrelated problems in the repo. They were in an earlier draft and have been pulled out into #15 (Prisma is wired into the build but imported nowhere), #16 (`vercel.json` crons a route that doesn't exist), and #17 (CI workflows are stale, plus an invalid `dependabot.yml` ecosystem). The README documents how things work, not what's broken.

Docs only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
