### PR TITLE
fix: remove vercel cron pointing at a nonexistent route

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,11 +3,5 @@
     "env": {
       "ENABLE_EXPERIMENTAL_COREPACK": "1"
     }
-  },
-  "crons": [
-    {
-      "path": "/api/mail/cron",
-      "schedule": "0 5 * * *"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
`vercel.json` scheduled a daily cron against `/api/mail/cron`. That route does not exist and, as far as the history goes, never did — so every day at 05:00 UTC Vercel invoked it, got a 404, and consumed a cron slot on the plan for nothing.

## The evidence

Every route file under `src/app/api/`:

```
src/app/api/mail/route.ts        → /api/mail
src/app/api/revalidate/route.ts  → /api/revalidate
```

That's the complete list. There is no `mail/cron/` directory, and no dynamic or catch-all segment anywhere under `src/app/api/` that could have absorbed the extra path segment (the only dynamic route in the app is `src/app/blog/[slug]`). Grepping the repo for `cron` returns exactly two hits, both of them the `vercel.json` entry being deleted here — nothing else in the codebase referenced the schedule, so there is no orphaned handler waiting to be hooked up.

## The decision: delete, not build

Deleting is right *regardless of how #15 is decided*, which is what makes it safe to do now in isolation:

- **If #15 removes Prisma** (which its own text leans toward), there is no queue to flush and the schedule has no work to do. Deleting is the final answer.
- **If #15 persists submissions instead**, the cron still needs a route that doesn't exist yet, and its shape depends entirely on decisions that haven't been made. Building a speculative handler now means guessing what it should do.

Meanwhile the entry costs something in both worlds: anyone reading `vercel.json` reasonably concludes there's a working scheduled mail job. There isn't. A config that describes infrastructure which doesn't exist is worse than no config, because it's believed.

If #15 lands on persistence and something genuinely needs a daily sweep, the cron gets re-added deliberately, in the same change that adds the real route. That's a better sequence than leaving a dead schedule parked in config hoping a handler shows up under it.

## Explicitly not done: repointing at `/api/mail`

The tempting one-character-cheaper fix is to drop `/cron` and let the schedule hit the route that does exist. That would be wrong:

- `src/app/api/mail/route.ts` exports **only `POST`**, and reads `name`, `email`, `subject`, and `message` off the parsed JSON body. Vercel crons issue `GET`, so the invocation would fail anyway.
- More importantly, it's semantically wrong even if it worked. That handler sends a contact email through Gmail SMTP from visitor-supplied input. It is a request handler for a form submission, not a scheduled job, and firing it on a timer is not a behaviour anyone wants.

Making a broken schedule *succeed* at the wrong thing is worse than leaving it 404ing.

## Relationship to #15

#16 was filed alongside #15 because the `isPending` boolean on the `Email` model plus a daily mail cron read like one unfinished "queue submissions, flush them daily" design. This PR settles only the config half — the half that is wrong on its own terms today, since the path resolves to nothing no matter what happens to Prisma. The `Email` model, `src/lib/db.ts`, the `prisma generate` step in `build`, and `DATABASE_URL` in the workflows are all untouched here and remain #15's call.

Scope is one file and one key. `build.env.ENABLE_EXPERIMENTAL_COREPACK` is unchanged, and the result parses as valid JSON with `build` as its only remaining top-level key.

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)
