### PR TITLE
chore: remove Instagram and Twitter from social links

### DIFF
--- a/src/components/IndexSlices/Contact.tsx
+++ b/src/components/IndexSlices/Contact.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { Content, asLink } from "@prismicio/client";
 import { SliceComponentProps } from "@prismicio/react";
-import { Envelope, GithubFill, LinkedinFill, TwitterFill } from "akar-icons";
+import { Envelope, GithubFill, LinkedinFill } from "akar-icons";
 
 export default function Contact({
   slice,
@@ -25,15 +25,6 @@ export default function Contact({
                   href="mailto:alvarezdasilvaj@gmail.com"
                 >
                   <Envelope
-                    className="transition-all hover:text-primary-600"
-                    size={36}
-                  />
-                </a>
-              );
-            case "Twitter":
-              return (
-                <a key={`link-${index}`} href={asLink(item.contact_link) ?? ""}>
-                  <TwitterFill
                     className="transition-all hover:text-primary-600"
                     size={36}
                   />

--- a/src/components/SocialmediaLinks.tsx
+++ b/src/components/SocialmediaLinks.tsx
@@ -1,9 +1,4 @@
-import {
-  faGithub,
-  faInstagram,
-  faLinkedinIn,
-  faTwitter,
-} from "@fortawesome/free-brands-svg-icons";
+import { faGithub, faLinkedinIn } from "@fortawesome/free-brands-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React from "react";
 
@@ -19,28 +14,6 @@ export default function SocialmediaLinks() {
         <FontAwesomeIcon
           className="h-6 w-6 cursor-pointer hover:text-primary-800 dark:hover:text-primary-500"
           icon={faGithub}
-        />
-      </a>
-      <a
-        title="Twitter"
-        href="https://twitter.com/Juanzenweb"
-        target="_blank"
-        rel="noreferrer"
-      >
-        <FontAwesomeIcon
-          className="h-6 w-6 cursor-pointer hover:text-primary-800 dark:hover:text-primary-500"
-          icon={faTwitter}
-        />
-      </a>
-      <a
-        title="Instagram"
-        href="https://www.instagram.com/soyjuansin/"
-        target="_blank"
-        rel="noreferrer"
-      >
-        <FontAwesomeIcon
-          className="h-6 w-6 cursor-pointer hover:text-primary-800 dark:hover:text-primary-500"
-          icon={faInstagram}
         />
       </a>
       <a


### PR DESCRIPTION
The socials row advertised four accounts, two of which are dead. Twitter/X in particular shouldn't be presented as a way to reach out. After this the socials are **GitHub** and **LinkedIn** only.

## What changed

- **`src/components/SocialmediaLinks.tsx`** — dropped the Twitter (`twitter.com/Juanzenweb`) and Instagram (`instagram.com/soyjuansin`) anchors along with the now-unused `faTwitter` / `faInstagram` imports from `@fortawesome/free-brands-svg-icons`.
- **`src/components/IndexSlices/Contact.tsx`** — dropped the `case "Twitter"` branch from the contact-slice switch and the `TwitterFill` import from `akar-icons`. `asLink` stays, it's still used by the GitHub and LinkedIn branches.

That's the whole diff: 2 files, +2 / -38.

## Where it lands

`SocialmediaLinks` is mounted in three places, so the single edit covers all of them:

- `src/components/IndexSlices/AboutMe.tsx:57` — homepage About Me aside
- `src/components/features/ContactPage/Information.tsx:17` — contact page
- `src/app/blog/[slug]/page.tsx:101` — blog post footer bio

Spacing holds up with two icons instead of four. The component is `flex w-fit space-x-6`, so `space-x-6` just puts one 1.5rem gap between the remaining pair and `w-fit` shrinks the box to match. Nothing downstream assumes a fixed width or a four-column grid: the About Me aside is `items-center` so the pair stays centered under the avatar, and the other two mounts are left-aligned in normal flow.

## Verified

```
$ pnpm lint
$ eslint .
(no output, exit 0)

$ pnpm exec tsc --noEmit
(no output, exit 0)
```

`tsc` initially reported seven pre-existing `TS2307: Cannot find module '@/public/images/...'` errors in `AboutMe.tsx` and `HeroAbout.tsx`. Those are unrelated to this change — they're the gitignored `next-env.d.ts` not existing yet in a fresh checkout, since it's what pulls in `next/image-types/global`. `pnpm exec next typegen` generates it and the run above is clean.

`grep -rn 'twitter\|instagram' src/` now returns only the two intentional leftovers below. No `pnpm build` — no `.env.local` in this checkout, and the change is presentational.

## Deliberately left out

- **`src/components/IndexSlices/AboutMe.tsx:28`** — the prose "I used Twitter to share my knowledge with the community" stays. It's past tense inside a paragraph about learning to code in 2020/2021, so it reads as history rather than as a live invitation to go find the account.
- **`src/app/blog/[slug]/page.tsx`** — the blog post Twitter *share intent* is untouched. It's a separate concern from "how to reach me" and is being handled in #12, so this branch keeps its hands off that file to avoid a conflict.

## Needs a manual step from you

The contact slice items come from Prismic, not from code, so **the Twitter entry has to be deleted from the Homepage document in the Prismic editor.** Nothing in this repo can do it.

Until you do, it degrades gracefully rather than breaking. `contact_label` is typed `prismic.KeyTextField` (a plain string, not a union of the four labels), so the switch was never exhaustive and has no `default` branch. A leftover `"Twitter"` item now falls through every case, the map callback returns `undefined`, and React renders nothing for it. No crash, no empty link, no console error — it just silently occupies a slot in the Prismic document that produces no output.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
