### PR TITLE
feat: add LinkedIn to blog post share links

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { PrismicRichText, PrismicText } from "@prismicio/react";
 import { Metadata } from "next";
 import Image from "next/image";
 import { notFound } from "next/navigation";
+import ShareLinks from "~/components/ShareLinks";
 import SocialmediaLinks from "~/components/SocialmediaLinks";
 import { H1, H4, Paragraph } from "~/components/utils/text";
 import { prismicClient } from "~/lib/prismic";
@@ -34,10 +35,6 @@ export default async function BlogPost({ params }: Props) {
 
   const currentUrl = "https://juanalvarez.dev";
   const link = `${currentUrl}/blog/${slug}`;
-  const twitterShare = `https://twitter.com/intent/tweet?url=${link}&text=${prismic.asText(
-    title,
-  )}`;
-  const fbShare = `http://www.facebook.com/share.php?u=${link}`;
 
   return (
     <main className="mx-auto max-w-[1080px] px-4 py-8">
@@ -61,30 +58,7 @@ export default async function BlogPost({ params }: Props) {
         </article>
       </main>
 
-      <section className="my-8 flex flex-col items-center gap-4 lg:flex-row">
-        <hr className="w-full text-gray-300 lg:w-2/3" />
-        <article className="flex w-full justify-between gap-4 px-4 lg:w-1/3">
-          <span className="uppercase text-gray-400">share</span>
-          <section className="space-x-12 lg:space-x-4">
-            <a
-              className="font-semibold text-primary-600 transition-colors hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
-              target="_blank"
-              rel="noreferrer"
-              href={twitterShare}
-            >
-              Twitter
-            </a>
-            <a
-              className="font-semibold text-primary-600 transition-colors hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
-              target="_blank"
-              rel="noreferrer"
-              href={fbShare}
-            >
-              Facebook
-            </a>
-          </section>
-        </article>
-      </section>
+      <ShareLinks url={link} title={prismic.asText(title)} />
 
       <footer className="my-8">
         <section className="flex gap-4">

--- a/src/components/ShareLinks.tsx
+++ b/src/components/ShareLinks.tsx
@@ -12,6 +12,9 @@ export default function ShareLinks({
 }) {
   const encodedUrl = encodeURIComponent(url);
   const linkedinShare = `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`;
+  const twitterShare = `https://x.com/intent/post?url=${encodedUrl}&text=${encodeURIComponent(
+    title
+  )}`;
   const facebookShare = `https://www.facebook.com/share.php?u=${encodedUrl}`;
 
   return (
@@ -19,7 +22,7 @@ export default function ShareLinks({
       <hr className="w-full text-gray-300 lg:w-2/3" />
       <article className="flex w-full justify-between gap-4 px-4 lg:w-1/3">
         <span className="uppercase text-gray-400">share</span>
-        <section className="space-x-12 lg:space-x-4">
+        <section className="space-x-6 lg:space-x-4">
           <a
             className={anchorClassName}
             target="_blank"
@@ -28,6 +31,15 @@ export default function ShareLinks({
             aria-label={`Share "${title}" on LinkedIn`}
           >
             LinkedIn
+          </a>
+          <a
+            className={anchorClassName}
+            target="_blank"
+            rel="noreferrer"
+            href={twitterShare}
+            aria-label={`Share "${title}" on Twitter`}
+          >
+            Twitter
           </a>
           <a
             className={anchorClassName}

--- a/src/components/ShareLinks.tsx
+++ b/src/components/ShareLinks.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+const anchorClassName =
+  "font-semibold text-primary-600 transition-colors hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300";
+
+export default function ShareLinks({
+  url,
+  title,
+}: {
+  url: string;
+  title: string;
+}) {
+  const encodedUrl = encodeURIComponent(url);
+  const linkedinShare = `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`;
+  const facebookShare = `https://www.facebook.com/share.php?u=${encodedUrl}`;
+
+  return (
+    <section className="my-8 flex flex-col items-center gap-4 lg:flex-row">
+      <hr className="w-full text-gray-300 lg:w-2/3" />
+      <article className="flex w-full justify-between gap-4 px-4 lg:w-1/3">
+        <span className="uppercase text-gray-400">share</span>
+        <section className="space-x-12 lg:space-x-4">
+          <a
+            className={anchorClassName}
+            target="_blank"
+            rel="noreferrer"
+            href={linkedinShare}
+            aria-label={`Share "${title}" on LinkedIn`}
+          >
+            LinkedIn
+          </a>
+          <a
+            className={anchorClassName}
+            target="_blank"
+            rel="noreferrer"
+            href={facebookShare}
+            aria-label={`Share "${title}" on Facebook`}
+          >
+            Facebook
+          </a>
+        </section>
+      </article>
+    </section>
+  );
+}


### PR DESCRIPTION
Readers could only share a post to Twitter or Facebook, which is exactly backwards for the audience this blog has. This adds a LinkedIn share intent alongside them, and since the surrounding code had to be touched anyway, fixes two things that were already broken in it.

## LinkedIn

`https://www.linkedin.com/sharing/share-offsite/?url=<encoded post url>`, rendered with the same anchor styles as the existing link.

Worth knowing: LinkedIn and Facebook both build their preview by scraping the page, they don't take a title or text parameter. The blog post page currently exports a static `metadata` of `title: "Juan Alvarez | Blog"` with a `// Mejorar esto` next to it and no Open Graph tags at all, so the preview card will be generic for every post. That's a separate problem from this one and isn't touched here, but it's the reason the share links can't carry the title themselves.

## Two bugs fixed along the way

**URLs were interpolated raw.** Both intents dropped `link` straight into a query parameter. Anything in it that a query string treats as a delimiter ended the parameter early:

| slug | what Facebook actually received |
| --- | --- |
| `tailwind-&-next-js` | `https://juanalvarez.dev/blog/tailwind-` |
| `css-tricks#2` | `https://juanalvarez.dev/blog/css-tricks` |

Both now go through `encodeURIComponent`, so the parameter round-trips exactly:

```
https://www.facebook.com/share.php?u=https%3A%2F%2Fjuanalvarez.dev%2Fblog%2Ftailwind-%26-next-js
```

The same bug hit the Twitter intent harder, because it interpolated the post title too — a title of `Tailwind & Next.js: tips #3` reached the composer as `Tailwind `, the raw `&` having terminated the parameter. Both halves now round-trip exactly, verified through `URL`/`searchParams`.

**Facebook was `http://`.** Now `https://`.

## Twitter stays

The issue left this as a judgement call. An earlier revision of this branch dropped the Twitter share for consistency with #11, which removes Twitter from the site's own social links. That was the wrong call and is reverted in `025d941`: it conflated whether the site advertises my Twitter profile with whether a reader can share a post there. A share intent posts from the *reader's* account, so the second doesn't follow from the first.

One change while restoring it — the host is now `x.com/intent/post` rather than `twitter.com/intent/tweet`. The old host only works by redirect, and #11's acceptance criteria ask for no `twitter.com` URLs left in `src/`. Behaviour is identical; flip it back if you'd rather keep the original host.

Net effect on the row: two links before (Twitter, Facebook), three after (LinkedIn, Twitter, Facebook).

## Extracted into a component

The nice-to-have in the issue, done — `src/components/ShareLinks.tsx`, taking `{ url, title }`. The page component was carrying 24 lines of share markup plus three URL constants for what is one self-contained widget, and this was the second time that markup was being edited.

- Anchor classes are byte-identical to before, hoisted into one `anchorClassName` constant instead of being copy-pasted per link.
- The component owns the whole row including the `<hr>`, so the page is down to `<ShareLinks url={link} title={prismic.asText(title)} />`.
- `title` does double duty: it goes into the Twitter intent text, and it labels every anchor for screen readers (`Share "<post title>" on LinkedIn`).

## Layout at mobile width

The issue flagged `space-x-12 lg:space-x-4` as a risk with an extra item, and with Twitter restored it is a real one — three links at 375px need roughly 40px more than the row has, so the mobile gap drops from `space-x-12` to `space-x-6` (3rem → 1.5rem, saving 48px across two gaps). `lg:space-x-4` is untouched.

**Worth an eyeball on the preview deploy.** That figure comes from measuring the text widths and the column's padding, not from looking at it in a browser — I have no browser here. The links are inline anchors in a block container, so the worst case if I'm off is a wrap to a second line, not horizontal overflow.

## Verification

- `pnpm lint` — clean.
- `pnpm exec tsc --noEmit` — clean. Note it reports 7 pre-existing `TS2307` errors on image imports in `IndexSlices/` in a fresh worktree; those come from `next-env.d.ts` not being generated yet, appear identically on an untouched tree, and vanish after `pnpm exec next typegen`.
- `pnpm exec prettier --check` on both files — clean.
- Encoding checked by round-tripping the generated intents through `URL`/`searchParams` for slugs containing `&`, `#`, and neither.

No `pnpm build`, no `.env.local` in this worktree.

Scope: only the two files above. `SocialmediaLinks.tsx` is rendered on this page but belongs to #11 and is left alone.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

