### PR TITLE
ci: migrate workflows to pnpm and node 22

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pnpm" # See documentation for possible values
+  - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,64 +1,39 @@
 name: Cypress
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
-  install:
-    runs-on: ubuntu-latest
-    container:
-      image: cypress/browsers:node18.12.0-chrome107
-      options: --user 1001
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Cypress install
-        uses: cypress-io/github-action@v5
-        with:
-          runTests: false
-          build: npm run github:build
-        env:
-          API_ENDPOINT: ${{ secrets.API_ENDPOINT }}
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-
-      - name: Save build folder
-        uses: actions/upload-artifact@v3
-        with:
-          name: build
-          path: .next
-          if-no-files-found: error
-
   e2e-chrome-tests:
     runs-on: ubuntu-latest
-    container:
-      image: cypress/browsers:node18.12.0-chrome107
-      options: --user 1001
-    needs: install
-    strategy:
-      fail-fast: false
-      matrix:
-        containers: [1, 2]
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
-      - name: Download the build folders
-        uses: actions/download-artifact@v3
-        with:
-          name: build
-          path: .next
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
 
-      - name: "UI Tests - Chrome"
-        uses: cypress-io/github-action@v5 # use the explicit version number
+      - name: Install Node.js
+        uses: actions/setup-node@v7
         with:
-          start: npm i
+          node-version: 22.x
+          cache: "pnpm"
+
+      - name: UI Tests - Chrome
+        uses: cypress-io/github-action@v7
+        with:
+          package-manager-cache: false
+          build: pnpm build
+          start: pnpm start
           wait-on: "http://localhost:3000"
           wait-on-timeout: 120
           browser: chrome
           record: true
-          parallel: true
-          group: "UI - Chrome"
-          spec: cypress/e2e/*
         env:
+          API_ENDPOINT: ${{ secrets.API_ENDPOINT }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -31,9 +31,6 @@ jobs:
           wait-on: "http://localhost:3000"
           wait-on-timeout: 120
           browser: chrome
-          record: true
         env:
           API_ENDPOINT: ${{ secrets.API_ENDPOINT }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,7 @@ name: Build
 on:
   push:
     branches: [main]
+  pull_request:
 
 jobs:
   build:
@@ -10,16 +11,23 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [22.x]
+
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "npm"
-      - run: npm ci
-      - run: npm run build --if-present
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
         env:
           API_ENDPOINT: ${{ secrets.API_ENDPOINT }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "dev:db-push": "prisma db push",
     "dev:db-migrate": "prisma migrate dev",
     "dev:db-studio": "prisma studio",
-    "prod:db-config": "prisma generate",
-    "github:build": "npm run prod:db-config && next build"
+    "prod:db-config": "prisma generate"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.4.0",


### PR DESCRIPTION
The repo had zero recorded workflow runs. Part of that is what the issue describes — both workflows ran `npm` against a repo whose only lockfile is `pnpm-lock.yaml`, so every run would have died on the first install step. But the more immediate reason turned out to be different, and it's the one thing in here that a merge does **not** fix. See "Both workflows are switched off" below. This rewrites both workflows so they can actually complete, and fixes the `dependabot.yml` ecosystem that was silently invalid.

## Both workflows are switched off

```
$ gh api repos/juanzenn/juanalvarez/actions/workflows --jq '.workflows[] | "\(.name): \(.state)"'
Cypress: disabled_manually
Build: disabled_manually
```

Repo-level Actions permissions are fine (`enabled: true, allowed_actions: all`) — it's the two workflows themselves that were manually disabled, last touched **2023-06-03**. That reframes the issue's premise: the broken `npm ci` never produced red checks because it never ran at all, and the "Heads up" prediction that pushes would kick off failing runs never came true for the same reason.

**This means merging this PR does not make CI start working.** Someone with repo admin has to re-enable both workflows — Actions tab → each workflow → "Enable workflow", or:

```
gh api -X PUT repos/juanzenn/juanalvarez/actions/workflows/47344935/enable  # Build
gh api -X PUT repos/juanzenn/juanalvarez/actions/workflows/48158815/enable  # Cypress
```

Worth doing that *after* this merges rather than before: until then, `main`'s `cypress.yml` still has `on: [push]`, so re-enabling first would fire a failing `npm ci` run on every open branch. That's the noise the issue's "Heads up" section anticipated, and merging first avoids it entirely.

The knock-on effect for this PR is that its own checks cannot be the proof they should have been. Nothing below has been observed on a runner — see "What a real run still has to prove".

## Every failure mode, and what it took

**`npm ci` with no `package-lock.json`.** Hard failure, both workflows. Replaced with `pnpm/action-setup` (which reads the version from the `packageManager` field, so `pnpm@11.17.0` is not duplicated in the YAML) followed by `actions/setup-node` with `cache: "pnpm"`. That ordering matters — `setup-node` shells out to `pnpm store path` to locate the cache, so pnpm has to exist first.

**Node 22, not 20.** The issue offered "Node 20 (or 22)". It has to be 22: `pnpm@11.17.0` declares `engines.node: ">=22.13"`, so a Node 20 runner installs pnpm and then pnpm refuses to run. Verified with `npm view pnpm@11.17.0 engines`. The matrix is down to a single entry — this is a portfolio site with one deploy target, so there is nothing to gain from testing a version range, but the matrix shape is left in place so adding one later is a one-line change.

**Retired action versions.** The issue said bump to v4, which was current when it was written; the current majors are `checkout@v7`, `setup-node@v7` and `cypress-io/github-action@v7` (v6 of the Cypress action is deprecated). The combination used here is copied from the Cypress action's own documented pnpm example, including `package-manager-cache: false` — the action would otherwise set up a second, competing pnpm cache on top of `setup-node`'s.

**The build workflow only ran on `push` to `main`.** Backwards, as the issue put it — the branch that most needs a green check is the one nobody has merged yet. Both workflows now run on `pull_request` plus pushes to `main`. Note the Cypress workflow was `on: [push]`, i.e. every push to every branch; narrowing it to `main` + PRs removes the duplicate run that a PR branch would otherwise trigger twice.

**`start: npm i` never served anything.** This was the most expensive bug in the file: it installed dependencies, exited, and left `wait-on: http://localhost:3000` waiting on a port nothing was listening to until the 120s timeout. It is now `build: pnpm build` / `start: pnpm start`, i.e. `next start` against a real build.

**The artifact hand-off is gone rather than bumped.** `upload-artifact@v3`/`download-artifact@v3` are retired and now hard-fail, so they had to change. But the only reason `.next` was being shipped between two jobs was to feed `parallel: true` across two containers, and with one spec file that parallelism is theatre — one container gets `homepage.cy.js`, the other gets nothing. Dropping `parallel` makes the containers matrix pointless, which makes the second job pointless, which makes the artifact round-trip pointless. Build and test now happen in one job. Worth noting this also sidestepped a trap: `upload-artifact@v4+` excludes hidden files by default, and `.next` is a hidden directory, so a naive v3→v7 bump would have uploaded an empty artifact and failed at `next start` with a confusing error.

**The `cypress/browsers:node18.12.0-chrome107` container is gone too.** With no parallel containers to keep in lockstep there is no reason to pay for a container image; `ubuntu-latest` ships Google Chrome preinstalled, so `browser: chrome` works directly on the runner.

**`dependabot.yml` had `package-ecosystem: "pnpm"`**, which is not a valid value — Dependabot reads `pnpm-lock.yaml` under the `npm` ecosystem. Changed to `npm`. This config has been invalid since it was written, which is why no update PRs have ever appeared.

## `CYPRESS_RECORD_KEY` exists, but recording is dropped anyway

`gh secret list` shows `CYPRESS_RECORD_KEY` present, set **2023-02-12** (alongside `API_ENDPOINT`, and nothing else). So the issue's stated condition for dropping `record` — a missing secret — is not what happened.

It's dropped regardless, and a secret existing is exactly the reason to be careful here rather than reassured: existence is not validity. That key is three years old and pairs with Cypress Cloud project `1fxcd6` in `cypress.config.ts`; if it was rotated, or the Cloud project was deleted or ran out of free-tier test recordings, `record: true` doesn't degrade — it errors the job out. The original plan was to keep it and let this PR's first run settle the question empirically, but with both workflows disabled there is no first run, so that check never happens.

Leaving an unverifiable external dependency in the one workflow that is supposed to start going green is the wrong trade for a suite whose entire content is `cy.visit("/")`. Plain it is, which is what the issue recommended for a site this size. `parallel: true` and `group:` are gone for the structural reasons above, and `GITHUB_TOKEN` went with them since it was only there to let the action attach the run to the commit.

Re-adding recording is a two-line change (`record: true` plus the `CYPRESS_RECORD_KEY` env) once someone confirms the Cloud project is still live.

## `DATABASE_URL` stays, and it should not

Kept in both workflows, because `pnpm build` still runs `prisma generate` and pulling the secret out is only safe once #15 decides Prisma's fate. Two findings that should make that decision easier:

1. **`DATABASE_URL` is not actually a repo secret.** `gh secret list` returns only `API_ENDPOINT` and `CYPRESS_RECORD_KEY`. So `${{ secrets.DATABASE_URL }}` has been expanding to an empty string all along.
2. **`prisma generate` does not care.** Verified locally: it succeeds with `DATABASE_URL` unset *and* with it set to `""`. The generator block needs no connection; only `db push`/`migrate` would.

So this is already a no-op that looks load-bearing. When #15 lands on removing Prisma, both `DATABASE_URL` lines come out with it, and nothing needs to be added to the repo's secrets in the meantime.

## `github:build` deleted

The script was `npm run prod:db-config && next build` — the npm-flavoured twin of `build`, which is `pnpm prod:db-config && next build`. Rather than fix the `npm run` inside it and keep two scripts that do the same thing, it's deleted and the workflow calls `pnpm build`. Confirmed nothing else referenced it: only `cypress.yml` did, and `vercel.json` sets build env but no build command.

## What a real run still has to prove

**No part of this has executed on a runner** — the workflows are disabled, so there are no checks on this PR to point at. That is the honest status, and it's the main thing a reviewer should weigh.

What *was* verified locally:

- All three YAML files parse.
- Every action version resolves to a real tag, and every input name is cross-checked against that action's current README rather than guessed. The `pnpm/action-setup@v6` + `setup-node@v7` + `cypress-io/github-action@v7` + `package-manager-cache: false` combination is lifted from the Cypress action's own documented pnpm example.
- `pnpm build` and `pnpm start` exist in `package.json`; nothing references the deleted `github:build`.
- `pnpm install --frozen-lockfile` succeeds against the committed lockfile.
- `prisma generate` succeeds with `DATABASE_URL` unset and empty.
- `pnpm@11.17.0` requires `node >=22.13`.
- Cypress 12.17.4 verifies its binary fine on a Node 22+ runtime, so the old Cypress pin is not a blocker for the Node bump.
- Cypress's default `specPattern` picks up `cypress/e2e/homepage.cy.js`, so the old `spec: cypress/e2e/*` override was redundant and is gone.
- `ubuntu-latest` ships Google Chrome preinstalled, which is what lets the container go.

What genuinely cannot be checked from outside a runner:

- Whether `next build` completes on a GitHub runner. The homepage is an `async` server component calling `getSingle("index")` and `getByType("blog_post")`, so the build performs live Prismic fetches and depends on `API_ENDPOINT` holding a valid repository name. Partial evidence: the Vercel preview deployment on this branch is green, and Vercel runs the same `build` script, so `prisma generate && next build` demonstrably works end to end *given a valid `API_ENDPOINT`*. What that does **not** confirm is the value of the GitHub Actions secret specifically — Vercel injects env from its own project settings, not from `secrets.API_ENDPOINT`. If the Actions run ever fails on a Prismic fetch, that secret is the first place to look.
- Whether `next start` comes up within the 120s `wait-on` window on a cold runner.
- Whether the 2023 `CYPRESS_RECORD_KEY` is still valid — moot now that recording is dropped, but still unknown.
- Whether Dependabot starts opening PRs. That runs on GitHub's schedule against `main`, so it isn't observable from a PR either way.

A follow-up worth considering separately: adding a `github-actions` ecosystem entry to `dependabot.yml` would stop action versions from rotting into the retired state that caused half of this issue. Left out here because it's a policy call, not a fix.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)
