### PR TITLE
feat: add Open Graph metadata so blog posts share with their own card

### DIFF
--- a/cypress/e2e/metadata.cy.js
+++ b/cypress/e2e/metadata.cy.js
@@ -1,0 +1,116 @@
+const SITE_URL = "https://juanalvarez.dev";
+
+const fetchDocument = (path, options = {}) =>
+  cy
+    .request({ url: path, ...options })
+    .then(({ body }) => new DOMParser().parseFromString(body, "text/html"));
+
+const meta = (doc, key) =>
+  doc
+    .querySelector(`meta[property="${key}"], meta[name="${key}"]`)
+    ?.getAttribute("content");
+
+const blogPostSlugs = () =>
+  cy.request("/blog").then(({ body }) => {
+    const slugs = [...body.matchAll(/href="\/blog\/([^"?#]+)"/g)].map(
+      (match) => match[1]
+    );
+
+    return [...new Set(slugs)];
+  });
+
+describe("Default site metadata", () => {
+  const pages = ["/", "/blog", "/contact"];
+
+  pages.forEach((path) => {
+    it(`gives ${path} a share card built on the default cover`, () => {
+      fetchDocument(path).then((doc) => {
+        const pageTitle = doc.querySelector("title").textContent;
+
+        expect(pageTitle).not.to.be.empty;
+        expect(meta(doc, "og:title")).to.equal(pageTitle);
+        expect(meta(doc, "og:description")).to.equal(meta(doc, "description"));
+        expect(meta(doc, "og:site_name")).to.equal("Juan Alvarez");
+        expect(meta(doc, "og:type")).to.equal("website");
+        expect(meta(doc, "og:image")).to.equal(`${SITE_URL}/cover.png`);
+        expect(meta(doc, "twitter:card")).to.equal("summary_large_image");
+      });
+    });
+  });
+
+  it("gives each page its own title", () => {
+    const titles = [];
+
+    pages.forEach((path) => {
+      fetchDocument(path).then((doc) => {
+        titles.push(doc.querySelector("title").textContent);
+      });
+    });
+
+    cy.then(() => {
+      expect(new Set(titles).size, "distinct titles").to.equal(pages.length);
+    });
+  });
+});
+
+describe("Blog post metadata", () => {
+  it("advertises the post's own title, description and cover image", () => {
+    blogPostSlugs().then(([slug]) => {
+      fetchDocument(`/blog/${slug}`).then((doc) => {
+        const heading = doc.querySelector("h1").textContent.trim();
+
+        expect(heading).not.to.be.empty;
+        expect(doc.querySelector("title").textContent).to.equal(heading);
+        expect(meta(doc, "og:title")).to.equal(heading);
+
+        expect(meta(doc, "description")).not.to.be.empty;
+        expect(meta(doc, "og:description")).to.equal(meta(doc, "description"));
+
+        expect(meta(doc, "og:type")).to.equal("article");
+        expect(meta(doc, "og:url")).to.equal(`${SITE_URL}/blog/${slug}`);
+
+        expect(meta(doc, "og:image")).to.match(
+          /^https:\/\/images\.prismic\.io\//
+        );
+        expect(Number(meta(doc, "og:image:width"))).to.be.greaterThan(0);
+        expect(Number(meta(doc, "og:image:height"))).to.be.greaterThan(0);
+
+        expect(meta(doc, "twitter:card")).to.equal("summary_large_image");
+      });
+    });
+  });
+
+  it("returns a 404 for a slug that matches no post", () => {
+    cy.request({
+      url: "/blog/no-post-has-ever-had-this-slug",
+      failOnStatusCode: false,
+    })
+      .its("status")
+      .should("equal", 404);
+  });
+
+  it("gives two different posts different titles and covers", () => {
+    blogPostSlugs().then((slugs) => {
+      expect(slugs.length, "posts available to compare").to.be.at.least(2);
+
+      const [first, second] = slugs;
+
+      fetchDocument(`/blog/${first}`).then((firstDoc) => {
+        fetchDocument(`/blog/${second}`).then((secondDoc) => {
+          expect(firstDoc.querySelector("title").textContent).not.to.equal(
+            secondDoc.querySelector("title").textContent
+          );
+          expect(meta(firstDoc, "og:title")).not.to.equal(
+            meta(secondDoc, "og:title")
+          );
+          expect(meta(firstDoc, "og:url")).not.to.equal(
+            meta(secondDoc, "og:url")
+          );
+          expect(meta(firstDoc, "og:image")).not.to.equal(
+            meta(secondDoc, "og:image")
+          );
+        });
+      });
+    });
+  });
+});

--- a/cypress/e2e/metadata.cy.js
+++ b/cypress/e2e/metadata.cy.js
@@ -1,8 +1,9 @@
 const SITE_URL = "https://juanalvarez.dev";
+const DEFAULT_COVER_URL = `${SITE_URL}/cover.png`;
 
-const fetchDocument = (path, options = {}) =>
+const fetchDocument = (path) =>
   cy
-    .request({ url: path, ...options })
+    .request(path)
     .then(({ body }) => new DOMParser().parseFromString(body, "text/html"));
 
 const meta = (doc, key) =>
@@ -10,10 +11,18 @@ const meta = (doc, key) =>
     .querySelector(`meta[property="${key}"], meta[name="${key}"]`)
     ?.getAttribute("content");
 
+const text = (doc, selector) => {
+  const element = doc.querySelector(selector);
+
+  expect(element, `${selector} in fetched document`).not.to.be.null;
+
+  return element.textContent.trim();
+};
+
 const blogPostSlugs = () =>
-  cy.request("/blog").then(({ body }) => {
-    const slugs = [...body.matchAll(/href="\/blog\/([^"?#]+)"/g)].map(
-      (match) => match[1]
+  fetchDocument("/blog").then((doc) => {
+    const slugs = [...doc.querySelectorAll('a[href^="/blog/"]')].map((anchor) =>
+      anchor.getAttribute("href").replace("/blog/", "")
     );
 
     return [...new Set(slugs)];
@@ -25,14 +34,17 @@ describe("Default site metadata", () => {
   pages.forEach((path) => {
     it(`gives ${path} a share card built on the default cover`, () => {
       fetchDocument(path).then((doc) => {
-        const pageTitle = doc.querySelector("title").textContent;
+        const pageTitle = text(doc, "title");
 
         expect(pageTitle).not.to.be.empty;
         expect(meta(doc, "og:title")).to.equal(pageTitle);
+
+        expect(meta(doc, "description")).not.to.be.empty;
         expect(meta(doc, "og:description")).to.equal(meta(doc, "description"));
+
         expect(meta(doc, "og:site_name")).to.equal("Juan Alvarez");
         expect(meta(doc, "og:type")).to.equal("website");
-        expect(meta(doc, "og:image")).to.equal(`${SITE_URL}/cover.png`);
+        expect(meta(doc, "og:image")).to.equal(DEFAULT_COVER_URL);
         expect(meta(doc, "twitter:card")).to.equal("summary_large_image");
       });
     });
@@ -43,7 +55,7 @@ describe("Default site metadata", () => {
 
     pages.forEach((path) => {
       fetchDocument(path).then((doc) => {
-        titles.push(doc.querySelector("title").textContent);
+        titles.push(text(doc, "title"));
       });
     });
 
@@ -57,10 +69,10 @@ describe("Blog post metadata", () => {
   it("advertises the post's own title, description and cover image", () => {
     blogPostSlugs().then(([slug]) => {
       fetchDocument(`/blog/${slug}`).then((doc) => {
-        const heading = doc.querySelector("h1").textContent.trim();
+        const heading = text(doc, "h1");
 
         expect(heading).not.to.be.empty;
-        expect(doc.querySelector("title").textContent).to.equal(heading);
+        expect(text(doc, "title")).to.equal(heading);
         expect(meta(doc, "og:title")).to.equal(heading);
 
         expect(meta(doc, "description")).not.to.be.empty;
@@ -69,9 +81,14 @@ describe("Blog post metadata", () => {
         expect(meta(doc, "og:type")).to.equal("article");
         expect(meta(doc, "og:url")).to.equal(`${SITE_URL}/blog/${slug}`);
 
-        expect(meta(doc, "og:image")).to.match(
-          /^https:\/\/images\.prismic\.io\//
-        );
+        if (doc.querySelector("header figure img")) {
+          expect(meta(doc, "og:image")).to.match(
+            /^https:\/\/images\.prismic\.io\//
+          );
+        } else {
+          expect(meta(doc, "og:image")).to.equal(DEFAULT_COVER_URL);
+        }
+
         expect(Number(meta(doc, "og:image:width"))).to.be.greaterThan(0);
         expect(Number(meta(doc, "og:image:height"))).to.be.greaterThan(0);
 
@@ -97,8 +114,8 @@ describe("Blog post metadata", () => {
 
       fetchDocument(`/blog/${first}`).then((firstDoc) => {
         fetchDocument(`/blog/${second}`).then((secondDoc) => {
-          expect(firstDoc.querySelector("title").textContent).not.to.equal(
-            secondDoc.querySelector("title").textContent
+          expect(text(firstDoc, "title")).not.to.equal(
+            text(secondDoc, "title")
           );
           expect(meta(firstDoc, "og:title")).not.to.equal(
             meta(secondDoc, "og:title")

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -7,7 +7,8 @@ import { notFound } from "next/navigation";
 import ShareLinks from "~/components/ShareLinks";
 import SocialmediaLinks from "~/components/SocialmediaLinks";
 import { H1, H4, Paragraph } from "~/components/utils/text";
-import { prismicClient } from "~/lib/prismic";
+import { getPostBySlug } from "~/lib/posts";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "~/lib/site";
 
 type Props = {
   params: Promise<{
@@ -15,26 +16,53 @@ type Props = {
   }>;
 };
 
-export const metadata: Metadata = {
-  // Mejorar esto
-  title: "Juan Alvarez | Blog",
-};
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const post = await getPostBySlug(slug);
+
+  if (!post) notFound();
+
+  const { title, description, cover } = post.data;
+
+  const postTitle = prismic.asText(title);
+  const postDescription = prismic.asText(description);
+
+  return {
+    title: postTitle,
+    description: postDescription,
+    openGraph: {
+      title: postTitle,
+      description: postDescription,
+      url: `/blog/${slug}`,
+      type: "article",
+      siteName: SITE_NAME,
+      images: prismic.isFilled.image(cover)
+        ? [
+            {
+              url: cover.url,
+              width: cover.dimensions.width,
+              height: cover.dimensions.height,
+              alt: cover.alt ?? postTitle,
+            },
+          ]
+        : [DEFAULT_OG_IMAGE],
+    },
+    twitter: {
+      card: "summary_large_image",
+    },
+  };
+}
 
 export default async function BlogPost({ params }: Props) {
-  const client = prismicClient();
   const { slug } = await params;
+  const post = await getPostBySlug(slug);
 
-  if (!slug) notFound();
-
-  const post = await client.getSingle("blog_post", {
-    predicates: [prismic.filter.at("my.blog_post.slug", slug)],
-  });
+  if (!post) notFound();
 
   const { data } = post;
   const { title, description, cover, content } = data;
 
-  const currentUrl = "https://juanalvarez.dev";
-  const link = `${currentUrl}/blog/${slug}`;
+  const link = `${SITE_URL}/blog/${slug}`;
 
   return (
     <main className="mx-auto max-w-[1080px] px-4 py-8">

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -8,7 +8,12 @@ import ShareLinks from "~/components/ShareLinks";
 import SocialmediaLinks from "~/components/SocialmediaLinks";
 import { H1, H4, Paragraph } from "~/components/utils/text";
 import { getPostBySlug } from "~/lib/posts";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "~/lib/site";
+import {
+  DEFAULT_OG_IMAGE,
+  SITE_DESCRIPTION,
+  SITE_NAME,
+  SITE_URL,
+} from "~/lib/site";
 
 type Props = {
   params: Promise<{
@@ -25,7 +30,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { title, description, cover } = post.data;
 
   const postTitle = prismic.asText(title);
-  const postDescription = prismic.asText(description);
+  const postDescription = prismic.asText(description) || SITE_DESCRIPTION;
 
   return {
     title: postTitle,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,12 +5,23 @@ import Footer from "~/components/Footer";
 import GoTop from "~/components/GoTop";
 import Navbar from "~/components/Navbar";
 import { cn } from "~/lib/cn";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "~/lib/site";
 import "./global.css";
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: "Juan Alvarez | Fullstack Web Developer, freelancer, and writer.",
   description:
     "I'm Juan, a fullstack web developer and freelancer, based in Venezuela. I build web applications and websites with quality in mind.",
+  openGraph: {
+    siteName: SITE_NAME,
+    type: "website",
+    locale: "en_US",
+    images: [DEFAULT_OG_IMAGE],
+  },
+  twitter: {
+    card: "summary_large_image",
+  },
 };
 
 export default async function RootLayout({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,18 +5,21 @@ import Footer from "~/components/Footer";
 import GoTop from "~/components/GoTop";
 import Navbar from "~/components/Navbar";
 import { cn } from "~/lib/cn";
-import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "~/lib/site";
+import {
+  DEFAULT_OG_IMAGE,
+  SITE_DESCRIPTION,
+  SITE_NAME,
+  SITE_URL,
+} from "~/lib/site";
 import "./global.css";
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: "Juan Alvarez | Fullstack Web Developer, freelancer, and writer.",
-  description:
-    "I'm Juan, a fullstack web developer and freelancer, based in Venezuela. I build web applications and websites with quality in mind.",
+  description: SITE_DESCRIPTION,
   openGraph: {
     siteName: SITE_NAME,
     type: "website",
-    locale: "en_US",
     images: [DEFAULT_OG_IMAGE],
   },
   twitter: {

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -5,14 +5,17 @@ import { prismicClient } from "~/lib/prismic";
 export const getPostBySlug = async (
   slug: string
 ): Promise<BlogPostDocument | null> => {
-  if (!slug) return null;
-
   try {
     return await prismicClient().getSingle("blog_post", {
       predicates: [prismic.filter.at("my.blog_post.slug", slug)],
     });
   } catch (error) {
-    if (error instanceof prismic.NotFoundError) return null;
+    if (
+      error instanceof prismic.NotFoundError &&
+      !(error instanceof prismic.RepositoryNotFoundError)
+    ) {
+      return null;
+    }
 
     throw error;
   }

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,0 +1,19 @@
+import * as prismic from "@prismicio/client";
+import type { BlogPostDocument } from "@/types.generated";
+import { prismicClient } from "~/lib/prismic";
+
+export const getPostBySlug = async (
+  slug: string
+): Promise<BlogPostDocument | null> => {
+  if (!slug) return null;
+
+  try {
+    return await prismicClient().getSingle("blog_post", {
+      predicates: [prismic.filter.at("my.blog_post.slug", slug)],
+    });
+  } catch (error) {
+    if (error instanceof prismic.NotFoundError) return null;
+
+    throw error;
+  }
+};

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,10 @@
+export const SITE_URL = "https://juanalvarez.dev";
+
+export const SITE_NAME = "Juan Alvarez";
+
+export const DEFAULT_OG_IMAGE = {
+  url: "/cover.png",
+  width: 1200,
+  height: 680,
+  alt: "Juan Alvarez, fullstack web developer",
+};

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,10 +1,19 @@
+import type { Metadata } from "next";
+
+type OpenGraphImage = NonNullable<
+  NonNullable<Metadata["openGraph"]>["images"]
+>;
+
 export const SITE_URL = "https://juanalvarez.dev";
 
 export const SITE_NAME = "Juan Alvarez";
+
+export const SITE_DESCRIPTION =
+  "I'm Juan, a fullstack web developer and freelancer, based in Venezuela. I build web applications and websites with quality in mind.";
 
 export const DEFAULT_OG_IMAGE = {
   url: "/cover.png",
   width: 1200,
   height: 680,
   alt: "Juan Alvarez, fullstack web developer",
-};
+} satisfies OpenGraphImage;


### PR DESCRIPTION
Share any blog post to LinkedIn, Facebook, Slack or iMessage today and you get a blank card reading "Juan Alvarez | Blog" — no title, no description, no image, identical for every post. That directly undercuts the LinkedIn share button #25 just added, because LinkedIn and Facebook build their preview by scraping Open Graph tags off the target page and ignore anything in the share intent URL. #25 said as much in its own body and left it as a separate problem; this is that problem.

The data was already in hand. The page component fetched `title`, `description` and `cover` and just never handed them to the metadata layer, because a static `metadata` export can't see route params.

## What changed

`src/app/blog/[slug]/page.tsx` swaps the static `metadata` export (the one with `// Mejorar esto` next to it) for `generateMetadata`. The two are mutually exclusive in a single route segment, so this is a replacement rather than an addition.

The Prismic query moved into `getPostBySlug(slug)` in `src/lib/posts.ts`, called by both `generateMetadata` and the page component. Two copies of `getSingle("blog_post", { predicates: [...] })` drifting apart is how one of them quietly starts resolving a different document. The query does now run twice per request, but production fetches with `force-cache` plus the `prismic` tag and dev revalidates every 5s, so the second call is a cache hit.

`src/lib/site.ts` holds `SITE_URL`, `SITE_NAME`, `SITE_DESCRIPTION` and `DEFAULT_OG_IMAGE`.

## Observed output

Two real posts, from `pnpm build && pnpm start` against the live Prismic repo:

`/blog/learn-javascript-closures-the-easy-way`

```html
<title>Learn JavaScript closures the easy way</title>
<meta name="description" content="JavaScript Closures are one of those strange (but very powerful) concepts to grasp. I'll walk you through this topic for an easy understanding."/>
<meta property="og:title" content="Learn JavaScript closures the easy way"/>
<meta property="og:description" content="JavaScript Closures are one of those strange (but very powerful) concepts to grasp. I'll walk you through this topic for an easy understanding."/>
<meta property="og:url" content="https://juanalvarez.dev/blog/learn-javascript-closures-the-easy-way"/>
<meta property="og:site_name" content="Juan Alvarez"/>
<meta property="og:image" content="https://images.prismic.io/juan-alvarez/da2b3dcd-840c-4bd8-abdc-e2f80e8b04a1_paul-earle-xJ2tjuUHD9M-unsplash.jpg?auto=compress,format&rect=0,155,1920,960&w=1200&h=600"/>
<meta property="og:image:width" content="1200"/>
<meta property="og:image:height" content="600"/>
<meta property="og:image:alt" content="Learn JavaScript closures the easy way"/>
<meta property="og:type" content="article"/>
<meta name="twitter:card" content="summary_large_image"/>
```

`/blog/two-sum---the-easiest-leetcode-exercise`

```html
<title>Two Sum - The easiest LeetCode exercise</title>
<meta property="og:title" content="Two Sum - The easiest LeetCode exercise"/>
<meta property="og:description" content="Working with algorithms is hard, even for the easiest one. Learn two ways of solving this problem with different time complexities!"/>
<meta property="og:url" content="https://juanalvarez.dev/blog/two-sum---the-easiest-leetcode-exercise"/>
<meta property="og:image" content="https://images.prismic.io/juan-alvarez/dYglAKtQiqIkNGxW_yiran-ding-JQRyYCC2OIM-unsplash.jpg?auto=format,compress&rect=0,274,4163,2082&w=1200&h=600"/>
<meta property="og:type" content="article"/>
```

Distinct title, description, url and cover per post.

## Judgement calls, all open to correction

**`public/cover.png` is wired up rather than deleted.** The issue left this as either/or. The file was 1200x680, committed, and referenced nowhere in the repo — it reads as an intended default share image that never got connected. It is now the default OG image for `/`, `/blog` and `/contact`, and the fallback for a post whose `cover` is unfilled. Its dimensions are hardcoded in `DEFAULT_OG_IMAGE`; replacing the file means updating those two numbers.

**`currentUrl` collapsed into `SITE_URL`, and `og:url` is relative.** `metadataBase: new URL(SITE_URL)` in the root layout, and the post asks for `url: "/blog/${slug}"`, which Next resolves against it. `SITE_URL` still builds the absolute string that `ShareLinks` needs, since a share intent can't take a relative URL. So one constant, two consumers, no second source of truth.

**The root layout's default `openGraph` deliberately omits `title` and `description`.** This looks like an oversight and isn't. Next's `inheritFromMetadata()` backfills both from whatever `title`/`description` the route itself resolved, so `/blog` gets `og:title` of "Juan Alvarez | Blog" and `/contact` gets "Juan Alvarez | Contact" for free. Setting them in the layout would freeze the site-level title into all three cards.

**It also omits `url`.** Segment metadata merges *shallowly*, so a layout-level `openGraph.url` would leak the homepage URL into every page that doesn't set its own — `/blog` and `/contact` would both advertise `og:url` of `https://juanalvarez.dev/`. Next emits `og:url` only when it's explicitly set, with no pathname default, so omitting it lets each scraper fall back to the URL it actually fetched.

That same shallow-merge rule is why the post's `openGraph` repeats `siteName` and carries its own `images` fallback: a segment that sets `openGraph` replaces the parent's wholesale rather than merging into it.

## Two bugs found along the way

**An unknown slug returned 500, not 404.** Pre-existing on `main`: `getSingle` throws `NotFoundError` when the filter matches nothing, and the page only guarded `if (!slug)`. `generateMetadata` resolves *before* the component, so it would have hit a bad slug first and thrown even earlier. `getPostBySlug` now returns `null` on that error and both callers call `notFound()`.

The catch deliberately excludes `RepositoryNotFoundError`, which extends `NotFoundError` and is thrown when the document API 404s on the repository itself. Without that exclusion a wrong `API_ENDPOINT` would render a tidy 404 on every post instead of failing loudly.

**A post with an empty description would have shipped no description at all.** `asText` on an empty field gives `""`. Next merges segments with a `for...in` loop, so a present-but-empty key overwrites the layout's description with `null` instead of inheriting it, and `inheritFromMetadata` then declines the `og:description` backfill because the value is falsy. Both now fall back to `SITE_DESCRIPTION`, which the layout also consumes.

## Tests

New `cypress/e2e/metadata.cy.js`, 7 tests. It fetches raw HTML with `cy.request` and parses it with `DOMParser` rather than driving a browser, which is closer to what a scraper actually does — no JS execution.

It asserts against the page's own rendered content rather than hardcoded strings: `og:title` must equal the post's `<h1>`, and `og:image` must be a `images.prismic.io` URL when the page rendered a cover or the default `cover.png` when it didn't. So it survives content edits in Prismic, and it fails if the metadata layer and the render layer ever disagree — which is exactly the bug being fixed here.

All 6 metadata assertions were confirmed red against `main` before implementing.

## Verification

Run against a production server, because a passing build proves nothing here — every route in this app is `ƒ (Dynamic)`, so no Prismic data is fetched at build time and these tags only exist at request time.

- `pnpm build && PORT=3100 pnpm start`, then curl. Both posts above are real output from that server, with real Prismic credentials.
- Two different posts give two different `<title>` and `og:title` values.
- `/`, `/blog` and `/contact` each emit `og:image` of `https://juanalvarez.dev/cover.png` (1200x680) alongside their own `og:title`; that URL serves 200.
- `pnpm exec cypress run` — 8/8 pass (7 new, 1 pre-existing).
- `pnpm lint` clean; `pnpm exec tsc --noEmit` clean after `pnpm exec next typegen`. (A bare `tsc` on a fresh worktree reports 7 phantom image-import errors — that's #26, not this.)
- **No `metadataBase` warning.** `pnpm build` output contains zero occurrences of the string `metadataBase` and zero lines matching `warn`.
- An unknown slug returns 404 (it returned 500 before), with nothing logged as an error server-side.

### Needs a manual step from you

**The scraper check in the issue's "Done when" is not done, and I could not do it.** LinkedIn Post Inspector and the Facebook Sharing Debugger both need a publicly reachable URL to fetch; a branch on a laptop has none. Everything above is HTML read off a local server, which is precisely the "not just reading the HTML" that checkbox was written to exclude. Please don't read a clean curl as scraper-verified.

**The Vercel preview on this PR is the fastest way to close it.** If a preview URL appears, paste it into [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/) and the [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) — for a post URL, not just the root. Two minutes, and it's the one piece of evidence I can't produce. Worth doing before merge: LinkedIn caches aggressively, and the Inspector's "Scrape Again" is how you clear a bad card once one is cached.

One caveat if you do: `og:url` on the preview will read `https://juanalvarez.dev/...`, since `metadataBase` is a hardcoded production URL. That's correct for production and intentional, but it means a scraper may follow the tag to the live site rather than reading the preview. If a preview card looks stale, that's why — check the tags the preview actually served.

**There is no GitHub Actions check on this PR.** The Build workflow is enabled but is not triggering — it reports zero runs, and the sibling PRs opened alongside this one show only Vercel and GitGuardian. Cypress remains disabled deliberately, so the suite above ran locally only. My local verification and the Vercel preview are the entire evidence base here.

## Done when

- [x] Each post's preview shows that post's own title, description and cover image
- [ ] **Verified against a real scraper** — not done, see above
- [x] `<title>` differs per post
- [x] `/`, `/blog` and `/contact` produce a sensible card
- [x] No `metadataBase` warning in the build output
- [x] `public/cover.png` wired up as the default OG image

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)
