### PR TITLE
fix: correct mobile menu toggle, active link and navigation a11y

### DIFF
--- a/cypress/e2e/navigation.cy.js
+++ b/cypress/e2e/navigation.cy.js
@@ -1,0 +1,165 @@
+const TRIGGER = 'button[aria-controls="mobile-menu"]';
+const MENU = "#mobile-menu";
+const CLOSE = '#mobile-menu button[aria-label="Close menu"]';
+const DESKTOP_NAV = "nav ul:not(#mobile-menu)";
+
+describe("Mobile navigation", () => {
+  beforeEach(() => {
+    cy.viewport("iphone-x");
+    cy.visit("/");
+  });
+
+  it("opens from the trigger and closes from the close button", () => {
+    cy.get(TRIGGER).should("have.attr", "aria-expanded", "false");
+    cy.get(MENU).should("not.exist");
+
+    cy.get(TRIGGER).click();
+    cy.get(MENU).should("be.visible");
+    cy.get(TRIGGER).should("have.attr", "aria-expanded", "true");
+
+    cy.get(CLOSE).click();
+    cy.get(MENU).should("not.exist");
+    cy.get(TRIGGER).should("have.attr", "aria-expanded", "false");
+  });
+
+  it("moves focus into the menu, closes on Escape and restores focus to the trigger", () => {
+    cy.get(TRIGGER).click();
+    cy.focused().should("have.attr", "aria-label", "Close menu");
+
+    cy.get("body").type("{esc}");
+
+    cy.get(MENU).should("not.exist");
+    cy.focused().should("have.attr", "aria-controls", "mobile-menu");
+  });
+
+  it("keeps Tab focus cycling inside the menu", () => {
+    cy.get(TRIGGER).click();
+
+    cy.get(`${MENU} a`).last().focus().trigger("keydown", { key: "Tab" });
+    cy.focused().should("have.attr", "aria-label", "Close menu");
+
+    cy.focused().trigger("keydown", { key: "Tab", shiftKey: true });
+    cy.focused().should("have.attr", "href", "/contact");
+  });
+
+  it("closes after navigating from a menu link", () => {
+    cy.get(TRIGGER).click();
+    cy.get(MENU).contains("a", "Blog").click();
+
+    cy.location("pathname").should("eq", "/blog");
+    cy.get(MENU).should("not.exist");
+    cy.get(TRIGGER).should("have.attr", "aria-expanded", "false");
+  });
+
+  it("closes when the browser navigates back", () => {
+    cy.get(TRIGGER).click();
+    cy.get(MENU).contains("a", "Blog").click();
+    cy.location("pathname").should("eq", "/blog");
+
+    cy.get(TRIGGER).click();
+    cy.get(MENU).should("be.visible");
+
+    cy.go("back");
+
+    cy.location("pathname").should("eq", "/");
+    cy.get(MENU).should("not.exist");
+  });
+
+  it("marks the current page inside the menu", () => {
+    cy.visit("/blog");
+    cy.get(TRIGGER).click();
+
+    cy.get(`${MENU} a[href="/blog"]`).should(
+      "have.attr",
+      "aria-current",
+      "page"
+    );
+    cy.get(`${MENU} a[href="/"]`).should("not.have.attr", "aria-current");
+  });
+
+  it("locks body scroll while open and restores it on close", () => {
+    cy.get("body").should("not.have.css", "overflow", "hidden");
+
+    cy.get(TRIGGER).click();
+    cy.get("body").should("have.css", "overflow", "hidden");
+
+    cy.get(CLOSE).click();
+    cy.get(MENU).should("not.exist");
+    cy.get("body").should("not.have.css", "overflow", "hidden");
+  });
+
+  it("restores body scroll when navigating away with the menu open", () => {
+    cy.get(TRIGGER).click();
+    cy.get("body").should("have.css", "overflow", "hidden");
+
+    cy.get(MENU).contains("a", "Blog").click();
+
+    cy.location("pathname").should("eq", "/blog");
+    cy.get("body").should("not.have.css", "overflow", "hidden");
+  });
+
+  it("anchors the backdrop to the viewport", () => {
+    cy.get(TRIGGER).click();
+
+    cy.get(MENU).parent().should("have.css", "position", "fixed");
+  });
+});
+
+describe("Scrolled navbar", () => {
+  const scrollTo = (offset) =>
+    cy.window().then((win) => {
+      win.scrollTo(0, offset);
+      win.dispatchEvent(new win.Event("scroll"));
+    });
+
+  it("gains the scrolled background once past the threshold", () => {
+    cy.viewport("iphone-x");
+    cy.visit("/");
+
+    cy.get(TRIGGER).click();
+    cy.get(MENU).should("be.visible");
+    cy.get(CLOSE).click();
+    cy.get(MENU).should("not.exist");
+
+    cy.get("nav").should("not.have.class", "shadow");
+
+    scrollTo(400);
+    cy.get("nav").should("have.class", "shadow");
+
+    scrollTo(0);
+    cy.get("nav").should("not.have.class", "shadow");
+  });
+});
+
+describe("Desktop navigation", () => {
+  beforeEach(() => {
+    cy.viewport(1440, 900);
+  });
+
+  it("marks only the home item on the homepage", () => {
+    cy.visit("/");
+
+    cy.get(DESKTOP_NAV)
+      .find('a[href="/"]')
+      .should("have.attr", "aria-current", "page");
+    cy.get(DESKTOP_NAV)
+      .find('a[href="/blog"]')
+      .should("not.have.attr", "aria-current");
+    cy.get(DESKTOP_NAV)
+      .find('a[href="/contact"]')
+      .should("not.have.attr", "aria-current");
+  });
+
+  it("keeps the blog item marked on a blog post page", () => {
+    cy.visit("/blog");
+    cy.get('a[href^="/blog/"]').first().click();
+
+    cy.location("pathname").should("match", /^\/blog\/.+/);
+    cy.get(DESKTOP_NAV)
+      .find('a[href="/blog"]')
+      .should("have.attr", "aria-current", "page");
+    cy.get(DESKTOP_NAV)
+      .find('a[href="/"]')
+      .should("not.have.attr", "aria-current");
+  });
+});

--- a/cypress/e2e/navigation.cy.js
+++ b/cypress/e2e/navigation.cy.js
@@ -22,6 +22,29 @@ describe("Mobile navigation", () => {
     cy.get(TRIGGER).should("have.attr", "aria-expanded", "false");
   });
 
+  it("toggles from the trigger without double-toggling itself", () => {
+    cy.get(TRIGGER).click();
+    cy.get(MENU).should("be.visible");
+
+    cy.get(TRIGGER).click({ force: true });
+    cy.get(MENU).should("not.exist");
+    cy.get(TRIGGER).should("have.attr", "aria-expanded", "false");
+
+    cy.get(TRIGGER).click();
+    cy.get(MENU).should("be.visible");
+    cy.get(TRIGGER).should("have.attr", "aria-expanded", "true");
+  });
+
+  it("does not close on the dismissing mousedown that precedes a trigger click", () => {
+    cy.get(TRIGGER).click();
+    cy.get(MENU).should("be.visible");
+
+    cy.get(TRIGGER).trigger("mousedown", { force: true });
+
+    cy.get(MENU).should("be.visible");
+    cy.get(TRIGGER).should("have.attr", "aria-expanded", "true");
+  });
+
   it("moves focus into the menu, closes on Escape and restores focus to the trigger", () => {
     cy.get(TRIGGER).click();
     cy.focused().should("have.attr", "aria-label", "Close menu");
@@ -106,27 +129,30 @@ describe("Mobile navigation", () => {
 });
 
 describe("Scrolled navbar", () => {
-  const scrollTo = (offset) =>
-    cy.window().then((win) => {
-      win.scrollTo(0, offset);
-      win.dispatchEvent(new win.Event("scroll"));
-    });
+  const scrollWindowTo = (offset) => {
+    cy.scrollTo(0, offset);
+    cy.window().then((win) => win.dispatchEvent(new win.Event("scroll")));
+  };
 
-  it("gains the scrolled background once past the threshold", () => {
-    cy.viewport("iphone-x");
-    cy.visit("/");
-
+  const openAndCloseMenuToProveHydration = () => {
     cy.get(TRIGGER).click();
     cy.get(MENU).should("be.visible");
     cy.get(CLOSE).click();
     cy.get(MENU).should("not.exist");
+  };
 
+  it("gains the scrolled background once past the threshold", () => {
+    cy.viewport("iphone-x");
+    cy.visit("/");
+    openAndCloseMenuToProveHydration();
+
+    scrollWindowTo(0);
     cy.get("nav").should("not.have.class", "shadow");
 
-    scrollTo(400);
+    scrollWindowTo(400);
     cy.get("nav").should("have.class", "shadow");
 
-    scrollTo(0);
+    scrollWindowTo(0);
     cy.get("nav").should("not.have.class", "shadow");
   });
 });

--- a/src/components/MobileMenu/MobileMenu.tsx
+++ b/src/components/MobileMenu/MobileMenu.tsx
@@ -1,8 +1,10 @@
 import { Cross } from "akar-icons";
 import { AnimatePresence, motion } from "framer-motion";
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { useOnClickOutside } from "usehooks-ts";
 import { backdropVariants, menuVariants } from "./variants";
+
+export const MOBILE_MENU_ID = "mobile-menu";
 
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])';
@@ -15,32 +17,34 @@ function MobileMenu({
 }: {
   onClose: () => void;
   open: boolean;
-  triggerRef?: React.RefObject<HTMLButtonElement>;
+  triggerRef: React.RefObject<HTMLButtonElement>;
   children: React.ReactNode;
 }) {
   const mobileNavRef = useRef<HTMLUListElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
 
-  const handleClickOutside = useCallback(
-    (event: MouseEvent | TouchEvent) => {
-      const target = event.target as Node | null;
+  useOnClickOutside(mobileNavRef, (event) => {
+    const target = event.target as Node | null;
 
-      if (target && triggerRef?.current?.contains(target)) return;
+    if (target && triggerRef.current?.contains(target)) return;
 
-      onClose();
-    },
-    [onClose, triggerRef]
-  );
-
-  useOnClickOutside(mobileNavRef, handleClickOutside);
+    onClose();
+  });
 
   useEffect(() => {
     if (!open) return;
 
-    const trigger = triggerRef?.current;
+    const trigger = triggerRef.current;
+    const menu = mobileNavRef.current;
     closeButtonRef.current?.focus();
 
-    return () => trigger?.focus();
+    return () => {
+      const active = document.activeElement;
+      const focusWasInsideMenu =
+        !active || active === document.body || !!menu?.contains(active);
+
+      if (focusWasInsideMenu) trigger?.focus();
+    };
   }, [open, triggerRef]);
 
   useEffect(() => {
@@ -102,7 +106,7 @@ function MobileMenu({
             animate="visible"
             exit="hidden"
             className="absolute top-0 right-0 flex h-screen w-3/4 flex-col gap-4 bg-gray-50 py-4 shadow-inner dark:bg-gray-800 md:w-1/2"
-            id="mobile-menu"
+            id={MOBILE_MENU_ID}
             ref={mobileNavRef}
           >
             <li className="mb-6 self-end">

--- a/src/components/MobileMenu/MobileMenu.tsx
+++ b/src/components/MobileMenu/MobileMenu.tsx
@@ -1,20 +1,88 @@
 import { Cross } from "akar-icons";
 import { AnimatePresence, motion } from "framer-motion";
-import React, { useRef } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { useOnClickOutside } from "usehooks-ts";
 import { backdropVariants, menuVariants } from "./variants";
 
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
 function MobileMenu({
-  handleClose,
+  onClose,
   open,
+  triggerRef,
   children,
 }: {
-  handleClose: () => void;
+  onClose: () => void;
   open: boolean;
+  triggerRef?: React.RefObject<HTMLButtonElement>;
   children: React.ReactNode;
 }) {
-  const mobileNavRef = useRef(null);
-  useOnClickOutside(mobileNavRef, handleClose);
+  const mobileNavRef = useRef<HTMLUListElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  const handleClickOutside = useCallback(
+    (event: MouseEvent | TouchEvent) => {
+      const target = event.target as Node | null;
+
+      if (target && triggerRef?.current?.contains(target)) return;
+
+      onClose();
+    },
+    [onClose, triggerRef]
+  );
+
+  useOnClickOutside(mobileNavRef, handleClickOutside);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const trigger = triggerRef?.current;
+    closeButtonRef.current?.focus();
+
+    return () => trigger?.focus();
+  }, [open, triggerRef]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const menu = mobileNavRef.current;
+      if (!menu) return;
+
+      const focusable = Array.from(
+        menu.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      const insideMenu = active instanceof Node && menu.contains(active);
+
+      if (event.shiftKey && (!insideMenu || active === first)) {
+        event.preventDefault();
+        last.focus();
+        return;
+      }
+
+      if (!event.shiftKey && (!insideMenu || active === last)) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
 
   return (
     <AnimatePresence presenceAffectsLayout>
@@ -25,7 +93,7 @@ function MobileMenu({
           initial="hidden"
           animate="visible"
           exit="hidden"
-          className="absolute top-0 flex h-screen w-screen justify-end overflow-hidden bg-black/60 lg:hidden"
+          className="fixed top-0 flex h-screen w-screen justify-end overflow-hidden bg-black/60 lg:hidden"
         >
           <motion.ul
             layout
@@ -34,13 +102,20 @@ function MobileMenu({
             animate="visible"
             exit="hidden"
             className="absolute top-0 right-0 flex h-screen w-3/4 flex-col gap-4 bg-gray-50 py-4 shadow-inner dark:bg-gray-800 md:w-1/2"
+            id="mobile-menu"
             ref={mobileNavRef}
           >
-            <Cross
-              className="mr-4 mb-6 self-end text-primary-900 dark:text-primary-500"
-              size={20}
-              onClick={handleClose}
-            />
+            <li className="mb-6 self-end">
+              <button
+                ref={closeButtonRef}
+                type="button"
+                aria-label="Close menu"
+                className="mr-4 block text-primary-900 dark:text-primary-500"
+                onClick={onClose}
+              >
+                <Cross size={20} />
+              </button>
+            </li>
             {children}
           </motion.ul>
         </motion.div>

--- a/src/components/MobileMenu/index.ts
+++ b/src/components/MobileMenu/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./MobileMenu";
+export { default, MOBILE_MENU_ID } from "./MobileMenu";

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,8 @@
 "use client";
 import Bars3Icon from "@heroicons/react/24/solid/Bars3Icon";
-import Link, { LinkProps } from "next/link";
-import React, { useEffect, useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useScroll } from "~/hooks/useScroll";
 import { cn } from "~/lib/cn";
 import MobileMenu from "./MobileMenu";
@@ -11,24 +12,47 @@ type Props = {
   defaultTheme?: string;
 };
 
-export default function Navbar({ defaultTheme }: Props) {
-  const [open, setOpen] = useState(false);
-  const scrolled = useScroll(50);
+const NAV_ITEMS = [
+  { href: "/", label: "Home" },
+  { href: "/blog", label: "Blog" },
+  { href: "/contact", label: "Contact" },
+];
 
-  const handleClose = () => setOpen(!open);
+const isCurrentPath = (pathname: string, href: string) =>
+  href === "/"
+    ? pathname === "/"
+    : pathname === href || pathname.startsWith(`${href}/`);
+
+export default function Navbar({ defaultTheme }: Props) {
+  const [isOpen, setIsOpen] = useState(false);
+  const scrolled = useScroll(50);
+  const pathname = usePathname();
+  const [renderedPathname, setRenderedPathname] = useState(pathname);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const closeMenu = useCallback(() => setIsOpen(false), []);
+  const toggleMenu = useCallback(() => setIsOpen((current) => !current), []);
+
+  if (pathname !== renderedPathname) {
+    setRenderedPathname(pathname);
+    setIsOpen(false);
+  }
 
   const navbarClass = cn(
-    "transition-all bg-transparent sticky top-0 isolate z-10 flex h-[56px] backdrop-blur flex-col items-center justify-center lg:flex-row lg:gap-8, py-2",
+    "transition-all bg-transparent sticky top-0 isolate z-10 flex h-[56px] backdrop-blur flex-col items-center justify-center lg:flex-row lg:gap-8 py-2",
     scrolled && "bg-white/50 dark:bg-gray-800/50 shadow"
   );
 
   useEffect(() => {
-    if (open) {
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "auto";
-    }
-  }, [open]);
+    if (!isOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOpen]);
 
   return (
     <nav className={navbarClass}>
@@ -41,28 +65,43 @@ export default function Navbar({ defaultTheme }: Props) {
         </Link>
 
         <div className="flex w-full justify-end lg:hidden">
-          <button className="lg:hidden " onClick={handleClose}>
+          <button
+            ref={triggerRef}
+            className="lg:hidden"
+            type="button"
+            aria-label="Main menu"
+            aria-expanded={isOpen}
+            aria-controls="mobile-menu"
+            onClick={toggleMenu}
+          >
             <Bars3Icon className="h-6 w-6 text-primary-900 dark:text-primary-500" />
           </button>
         </div>
       </article>
 
       <ul className="hidden w-screen items-center gap-4 font-medium lg:flex lg:justify-start">
-        <LinkItem href="/">Home</LinkItem>
-        <LinkItem href="/blog">Blog</LinkItem>
-        <LinkItem href="/contact">Contact</LinkItem>
+        {NAV_ITEMS.map(({ href, label }) => (
+          <LinkItem
+            key={href}
+            href={href}
+            active={isCurrentPath(pathname, href)}
+          >
+            {label}
+          </LinkItem>
+        ))}
       </ul>
 
-      <MobileMenu open={open} handleClose={handleClose}>
-        <LinkItem onClick={handleClose} href="/">
-          Home
-        </LinkItem>
-        <LinkItem onClick={handleClose} href="/blog">
-          Blog
-        </LinkItem>
-        <LinkItem onClick={handleClose} href="/contact">
-          Contact
-        </LinkItem>
+      <MobileMenu open={isOpen} onClose={closeMenu} triggerRef={triggerRef}>
+        {NAV_ITEMS.map(({ href, label }) => (
+          <LinkItem
+            key={href}
+            href={href}
+            active={isCurrentPath(pathname, href)}
+            onClick={closeMenu}
+          >
+            {label}
+          </LinkItem>
+        ))}
 
         <ThemeButton defaultTheme={defaultTheme} />
       </MobileMenu>
@@ -74,15 +113,29 @@ export default function Navbar({ defaultTheme }: Props) {
   );
 }
 
+type LinkItemProps = {
+  href: string;
+  children: React.ReactNode;
+  active?: boolean;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+};
+
 const LinkItem = ({
   href,
   children,
-  ...rest
-}: LinkProps & React.HTMLAttributes<HTMLLIElement>) => (
-  <li {...rest}>
+  active = false,
+  onClick,
+}: LinkItemProps) => (
+  <li>
     <Link
       href={href}
-      className="block py-2 px-6 text-xl font-medium hover:bg-gray-100 dark:hover:bg-gray-700 lg:rounded-md lg:py-1 lg:px-3 lg:text-base lg:transition-colors"
+      onClick={onClick}
+      aria-current={active ? "page" : undefined}
+      className={cn(
+        "block py-2 px-6 text-xl font-medium hover:bg-gray-100 dark:hover:bg-gray-700 lg:rounded-md lg:py-1 lg:px-3 lg:text-base lg:transition-colors",
+        active &&
+          "bg-gray-100 text-primary-800 dark:bg-gray-700 dark:text-primary-400"
+      )}
     >
       {children}
     </Link>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useScroll } from "~/hooks/useScroll";
 import { cn } from "~/lib/cn";
-import MobileMenu from "./MobileMenu";
+import MobileMenu, { MOBILE_MENU_ID } from "./MobileMenu";
 import ThemeButton from "./ThemeButton";
 
 type Props = {
@@ -71,7 +71,7 @@ export default function Navbar({ defaultTheme }: Props) {
             type="button"
             aria-label="Main menu"
             aria-expanded={isOpen}
-            aria-controls="mobile-menu"
+            aria-controls={MOBILE_MENU_ID}
             onClick={toggleMenu}
           >
             <Bars3Icon className="h-6 w-6 text-primary-900 dark:text-primary-500" />
@@ -103,7 +103,9 @@ export default function Navbar({ defaultTheme }: Props) {
           </LinkItem>
         ))}
 
-        <ThemeButton defaultTheme={defaultTheme} />
+        <li className="self-end">
+          <ThemeButton defaultTheme={defaultTheme} />
+        </li>
       </MobileMenu>
 
       <span className="hidden lg:block">

--- a/src/hooks/useScroll.ts
+++ b/src/hooks/useScroll.ts
@@ -1,24 +1,19 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 export const useScroll = (scrolledValue = 200) => {
   const [scrolled, setScrolled] = useState(false);
 
-  const handleScroll = useCallback(() => {
-    const offset = window.scrollY;
-    setScrolled(offset > scrolledValue);
-  }, [scrolledValue]);
-
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      window.addEventListener("scroll", handleScroll);
-    }
+    const handleScroll = () => {
+      const isScrolled = window.scrollY > scrolledValue;
 
-    return () => {
-      if (typeof window !== "undefined") {
-        window.removeEventListener("scroll", handleScroll);
-      }
+      setScrolled((current) => (current === isScrolled ? current : isScrolled));
     };
-  }, [handleScroll]);
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [scrolledValue]);
 
   return scrolled;
 };


### PR DESCRIPTION
Tapping the hamburger while the mobile menu was open often did nothing: `handleClose` was really a toggle (`() => setOpen(!open)`) wired simultaneously to the trigger's `onClick`, to `useOnClickOutside` inside `MobileMenu`, and to every `LinkItem`, so one gesture could fire two toggles and land back where it started. Closing the menu also wrote `document.body.style.overflow = "auto"` unconditionally instead of restoring the previous value, and had no unmount cleanup, so navigating away with the menu open left the page unscrollable. Around those two, the backdrop was `absolute` rather than `fixed`, `lg:gap-8,` carried a stray comma that made Tailwind drop the class, nothing marked the current page, and the menu was not operable by keyboard. This is the focused pass #14 asked for — every item on its list, no redesign.

## The toggle bug

`closeMenu` and `toggleMenu` replace the single overloaded `handleClose`. The trigger toggles; everything else closes. The subtle part is the outside-click handler, which now returns early when the event originates inside the trigger:

```ts
useOnClickOutside(mobileNavRef, (event) => {
  const target = event.target as Node | null;

  if (target && triggerRef.current?.contains(target)) return;

  onClose();
});
```

Without that guard the trigger's own dismissing `mousedown` closes the menu and its `click` immediately toggles it back open — the same double-fire in a new shape. Two specs pin it (`toggles from the trigger without double-toggling itself`, `does not close on the dismissing mousedown that precedes a trigger click`), because this is the line a future refactor is most likely to delete as redundant.

**One thing to be aware of, and I may be reading the layout wrong — push back if so.** Both of those specs click the trigger with `{ force: true }`. The trigger lives in the non-positioned `<article>` inside `nav.isolate`, while the backdrop and the slide-in panel are positioned descendants later in DOM order, so they paint above it. A real second tap at the hamburger's coordinates therefore lands on the panel's close button, which sits in almost exactly the same top-right spot the hamburger occupied — visible in the screenshot I took while checking this, where the focused `X` is right where the bars were. So the user-visible behaviour ("tap the top-right icon to open, tap it again to close") is correct, but it is correct via the close button, not via `toggleMenu`. The forced click is what lets a spec address the trigger's own handler rather than whatever is painted over it. I deliberately did **not** raise the trigger above the overlay: doing so would put a second close affordance directly on top of the panel's own, and #14 explicitly asks for the panel's `Cross` to become a real `<button>`.

`open()` is absent. #14 says "Split into explicit `open()` / `close()` / `toggle()`", but nothing in the component needs a bare open — the trigger toggles and every other path closes — so adding one would be dead code. Flagging it as a deliberate departure from the letter of the ticket.

## Body scroll lock

The effect now captures the previous inline value and restores it from its cleanup, which covers close and unmount with the same code path:

```ts
useEffect(() => {
  if (!isOpen) return;

  const previousOverflow = document.body.style.overflow;
  document.body.style.overflow = "hidden";

  return () => {
    document.body.style.overflow = previousOverflow;
  };
}, [isOpen]);
```

`restores body scroll when navigating away with the menu open` covers the symptom the ticket describes. To be precise about what it proves: the `LinkItem` it clicks carries `onClick={closeMenu}`, so the spec exercises the close path, not literally an unmount. `Navbar` lives in the root layout and never unmounts in this app, so the unmount branch is not reachable from an e2e test — it is covered by the effect early-returning before it registers any cleanup, so the only way cleanup exists is if the lock was applied.

## Active link and closing on navigation

`usePathname()` drives both. `isCurrentPath` matches `/` exactly and everything else by `href` or `${href}/` prefix, so `/blog/some-post` keeps Blog marked without `/blog` also matching a hypothetical `/blogroll`. The marked item gets `aria-current="page"` plus a background and colour shift.

Closing on route change is done by adjusting state during render rather than in an effect:

```ts
if (pathname !== renderedPathname) {
  setRenderedPathname(pathname);
  setIsOpen(false);
}
```

That is React's documented reset-on-prop-change pattern, and it is not a stylistic preference — the effect version fails lint:

```
$ pnpm lint
/src/components/Navbar.tsx
  41:5  error  Calling setState synchronously within an effect can trigger cascading renders
               react-hooks/set-state-in-effect
```

The per-link `onClick={closeMenu}` stays, and is not redundant: clicking the link for the page you are already on produces no pathname change, so without it that tap would leave the menu open.

## Accessibility

- Trigger gains `aria-label`, `aria-expanded` and `aria-controls`. The id is exported as `MOBILE_MENU_ID` so `aria-controls` and `id` cannot drift apart. Note `aria-controls` points at an element that only exists while open, since `AnimatePresence` unmounts the panel — the usual trade for an animated menu, and #14 asks for the attribute explicitly.
- The close `Cross` was a bare `<svg onClick>`. It is now a real `<button aria-label="Close menu">` inside an `<li>` that carries the alignment classes, so the visual position is unchanged.
- Escape closes, via a `document` keydown listener registered only while open.
- Opening focuses the close button; closing returns focus to the trigger, but only when focus was still inside the menu (or nowhere), so dismissing does not yank focus off something else.
- Tab and Shift+Tab cycle within the panel.
- `LinkItem` spread `onClick` onto the `<li>`; it is now on the `<a>`, and the prop type is explicit instead of `LinkProps & React.HTMLAttributes<HTMLLIElement>`.

**`ThemeButton` is the one thing here that is still not keyboard-reachable.** It renders a bare `<svg onClick>`, so it never took focus, and it is excluded from the focus trap's `FOCUSABLE_SELECTOR` for the same reason. That predates this issue and lives in `src/components/ThemeButton.tsx`, outside the three files #14 scopes, so I left the component alone — but I did wrap it in an `<li>`, because leaving it as the only non-`<li>` child of a `<ul>` whose other children I had just fixed would have been a worse inconsistency. Measured before and after: the icon's right edge stays 24px from the panel edge, so the wrap is visually inert. Making the theme toggle a real button is worth its own issue.

## Duplication and useScroll

The three nav items are one `NAV_ITEMS` array mapped over in both the desktop `<ul>` and the mobile menu. `useScroll` now registers `{ passive: true }` and only writes state when the boolean flips; the `typeof window !== "undefined"` guards are gone, since effects never run on the server. On the flip-only write — `setScrolled((current) => (current === isScrolled ? current : isScrolled))` is what the ticket asks for, though React would bail out on an `Object.is`-equal value anyway, so its practical value is that it states the intent rather than that it saves a render.

## Verification

All local. Exact invocations:

```
$ pnpm lint
$ eslint .
                                          # exit 0, no output

$ pnpm exec next typegen && pnpm exec tsc --noEmit
Generating route types...
✓ Types generated successfully
                                          # exit 0

$ pnpm build
✓ Compiled successfully
✓ Generating static pages using 9 workers (7/7)
```

`tsc --noEmit` needs `next typegen` first — a bare run fails on phantom image-import errors on a fresh checkout, which is #26, not this branch.

Cypress, against `next start` on port 3010 (a production build, not `next dev`):

```
$ TS_NODE_COMPILER_OPTIONS='{"moduleResolution":"node","module":"commonjs"}' \
    pnpm exec cypress run --config video=false,baseUrl=http://localhost:3010

  Mobile navigation
    ✓ opens from the trigger and closes from the close button
    ✓ toggles from the trigger without double-toggling itself
    ✓ does not close on the dismissing mousedown that precedes a trigger click
    ✓ moves focus into the menu, closes on Escape and restores focus to the trigger
    ✓ keeps Tab focus cycling inside the menu
    ✓ closes after navigating from a menu link
    ✓ closes when the browser navigates back
    ✓ marks the current page inside the menu
    ✓ locks body scroll while open and restores it on close
    ✓ restores body scroll when navigating away with the menu open
    ✓ anchors the backdrop to the viewport

  Scrolled navbar
    ✓ gains the scrolled background once past the threshold

  Desktop navigation
    ✓ marks only the home item on the homepage
    ✓ keeps the blog item marked on a blog post page

  14 passing (8s)

  ✔  All specs passed!   15   15   -   -   -
```

15/15 including the pre-existing `homepage.cy.js`, stable across three consecutive runs.

**That `TS_NODE_COMPILER_OPTIONS` prefix is not optional.** Without it `cypress run` cannot load `cypress.config.ts` at all — Cypress 12's bundled ts-node forces `module: commonjs` against this repo's `moduleResolution: "bundler"`:

```
Your configFile is invalid: cypress.config.ts
TSError: ⨯ Unable to compile TypeScript:
error TS5095: Option 'bundler' can only be used when 'module' is set to
'preserve' or to 'es2015' or later.
```

This reproduces on `main` and is unrelated to this branch, so it is left alone here. Two sibling agents hit it independently and used the same workaround. It does mean nobody can run this suite with the documented command until it is fixed, which is worth an issue of its own.

**Before/after check.** All 12 specs that existed at the first commit were confirmed to fail against the pre-change source (`git stash push src/`, run, `git stash pop`), so they are pinning behaviour rather than describing whatever the code happened to do.

### What is *not* verified

**Nothing here ran in CI, and probably nothing will.** The Cypress workflow is switched off:

```
$ gh api repos/:owner/:repo/actions/workflows --jq '.workflows[] | "\(.name) | \(.state)"'
Cypress | disabled_manually
Build | active
Dependabot Updates | active
```

So `navigation.cy.js` has no CI safety net whatsoever — it exists to be run by hand until someone re-enables that workflow (#28 covers the history there).

The Build workflow is `active` and `main`'s copy is configured `on: pull_request`, so in principle this PR should get a check. In practice the three sibling PRs open right now show only `Vercel` and `GitGuardian Security Checks`, no Actions check, and the repo has exactly one recorded run ever — a failed Dependabot run on `main`. I cannot tell from here whether that is a settings issue or just timing, so treat a green Build check on this PR as unproven rather than expected.

**Two specs are weaker than their names suggest**, and I would rather say so than let them read as stronger coverage:

- `keeps Tab focus cycling inside the menu` dispatches `trigger("keydown", { key: "Tab" })`. Cypress 12 has no native tab support, so focus moves only because the handler calls `.focus()`. It proves the wrap-around branches compute the right target; it would still pass if `preventDefault()` were removed, and it does not prove a real Tab press is intercepted. The trap logic itself is straightforward — `keydown` plus `preventDefault` does cancel native tabbing — but that part is reasoned, not observed.
- `gains the scrolled background once past the threshold` dispatches a synthetic `scroll` event, because `cy.scrollTo` moves the page without emitting one in this Electron build (I confirmed this: a listener registered before `cy.scrollTo` counted zero events while `window.scrollY` reached 400). It also asserts on the Tailwind class `shadow`, which is cosmetic and would need updating if the scrolled treatment changes. It exists as a regression guard for the `useScroll` refactor, not as a behavioural requirement from #14.

The focus behaviours are genuinely exercised, though: `moves focus into the menu, closes on Escape and restores focus to the trigger` asserts `cy.focused()` is the close button after opening, sends a real `{esc}`, and asserts `cy.focused()` is back on the trigger afterwards.

## Done when

- [x] Tapping the hamburger reliably opens and closes the menu — with the occlusion caveat above: the second tap lands on the close button at the same coordinates, and the trigger's own toggle is covered by a forced-click spec
- [x] Body scroll is restored on close and on unmount — close is covered by spec; unmount is unreachable e2e (root-layout component) and covered structurally
- [x] Current page is visually marked in both desktop and mobile nav — `aria-current="page"` plus styling, specs at both breakpoints and on a post page
- [x] Nav items defined once — single `NAV_ITEMS`
- [x] Menu is fully keyboard-operable: Tab into it, Escape closes it, focus returns to the trigger — except `ThemeButton`, which was never focusable and sits outside this issue's files
- [x] Existing `cypress/e2e/homepage.cy.js` still passes; add coverage for open → navigate → closed — 15/15; `closes after navigating from a menu link` plus `closes when the browser navigates back`

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)
