### PR TITLE
feat: redesign the projects card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 # next.js
 /.next/
 /out/
+AGENTS.md
+CLAUDE.md
 
 # typescript
 *.tsbuildinfo

--- a/src/components/IndexSlices/Projects.tsx
+++ b/src/components/IndexSlices/Projects.tsx
@@ -1,7 +1,10 @@
-import { Content, asLink } from "@prismicio/client";
+import { Content, asLink, asText } from "@prismicio/client";
 import { PrismicRichText, SliceComponentProps } from "@prismicio/react";
 import { GithubFill, LinkOut } from "akar-icons";
 import { H2, H3 } from "../utils/text";
+
+const FOCUS_RING =
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-50 dark:focus-visible:ring-primary-400 dark:focus-visible:ring-offset-gray-700";
 
 export default function Projects({
   slice,
@@ -26,45 +29,84 @@ export default function Projects({
         </span>
       </header>
 
-      <main className="grid gap-6 lg:grid-cols-2">
-        {items.map((item, index) => (
-          <article key={`project-${index}`}>
-            <header className="mb-2">
-              <span className="text-sm font-bold uppercase tracking-wide text-primary-700 dark:text-primary-500">
-                {item.project_type}
-              </span>
-              <PrismicRichText
-                field={item.project_title}
-                components={{
-                  heading3: ({ children }) => <H3>{children}</H3>,
-                }}
-              />
-            </header>
+      <section className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {items.map((item, index) => {
+          const liveHref = asLink(item.link);
+          const githubHref = asLink(item.github_link);
+          const [intro] = item.project_description;
+          const title = asText(item.project_title);
 
-            <article className="prose prose-strong:text-gray-600 dark:text-gray-100">
-              <PrismicRichText field={item.project_description} />
+          return (
+            <article
+              key={`project-${index}`}
+              className="flex flex-col rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-600 dark:bg-gray-700"
+            >
+              <header className="mb-3">
+                {item.project_type && (
+                  <span className="inline-block rounded-full bg-primary-50 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-primary-700 dark:bg-primary-500/10 dark:text-primary-300">
+                    {item.project_type}
+                  </span>
+                )}
+
+                <PrismicRichText
+                  field={item.project_title}
+                  components={{
+                    heading3: ({ children }) => (
+                      <H3 className="mt-2">
+                        {liveHref ? (
+                          <a
+                            href={liveHref}
+                            className={`rounded transition-colors hover:text-primary-700 dark:hover:text-primary-300 ${FOCUS_RING}`}
+                          >
+                            {children}
+                          </a>
+                        ) : (
+                          children
+                        )}
+                      </H3>
+                    ),
+                  }}
+                />
+              </header>
+
+              {intro && (
+                <PrismicRichText
+                  field={[intro]}
+                  components={{
+                    paragraph: ({ children }) => (
+                      <p className="mb-6 text-gray-600 dark:text-gray-200">
+                        {children}
+                      </p>
+                    ),
+                  }}
+                />
+              )}
+
+              <footer className="mt-auto flex items-center gap-3">
+                {liveHref && (
+                  <a
+                    href={liveHref}
+                    className={`flex items-center gap-2 rounded bg-primary-700 py-2 px-4 text-sm font-semibold text-white transition duration-300 hover:bg-primary-800 ${FOCUS_RING}`}
+                  >
+                    Live View
+                    <LinkOut size={18} />
+                  </a>
+                )}
+
+                {githubHref && (
+                  <a
+                    href={githubHref}
+                    aria-label={`${title} on GitHub`}
+                    className={`flex items-center rounded border border-gray-300 p-2 text-gray-700 transition duration-300 hover:bg-gray-100 dark:border-gray-500 dark:text-gray-100 dark:hover:bg-gray-600 ${FOCUS_RING}`}
+                  >
+                    <GithubFill size={18} />
+                  </a>
+                )}
+              </footer>
             </article>
-
-            <section className="flex items-center justify-center gap-6">
-              <a
-                href={asLink(item.github_link) ?? ""}
-                className="flex w-max items-center gap-2 rounded bg-gray-700 py-2 px-6 text-center text-base font-semibold text-white transition duration-300 hover:bg-gray-800"
-              >
-                GitHub
-                <GithubFill size={20} />
-              </a>
-
-              <a
-                href={asLink(item.link) ?? ""}
-                className="flex w-max items-center gap-2 rounded bg-primary-700 py-2 px-6 text-center text-base font-semibold text-white transition duration-300 hover:bg-primary-800"
-              >
-                Live View
-                <LinkOut size={20} />
-              </a>
-            </section>
-          </article>
-        ))}
-      </main>
+          );
+        })}
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
Design pass on the projects slice. Scope is `Projects.tsx` only — no Prismic changes, no design tokens, no dependency on #19 or #21.

## Card

- Real container: `rounded-lg`, border, white / `gray-700` surface, padding, shadow
- `project_type` becomes a chip instead of loose uppercase text
- Description renders the first block only. `prose` is gone, so both themes are named explicitly instead of light inheriting from the typography plugin
- Grid is `sm:grid-cols-2 lg:grid-cols-3`. Three projects in a 2-column grid left the third alone in its own row, and there was no tablet breakpoint at all
- Title links to the live site. The card itself is not clickable and has no hover state — that is the title and the buttons' job

## Fixes

- `href={asLink(...) ?? ""}` rendered a dead link back to the current page. Both CTAs now render only when their link resolves
- Nested `<article>` (one for the card, another for the body) is now one per card: `<header>` / `<p>` / `<footer>`
- The slice opened a second `<main>`; `layout.tsx` already has one. Now a `<section>`
- CTA row is left-aligned and pins with `mt-auto` instead of being centered under left-aligned copy
- `focus-visible` rings on all three links
- GitHub drops to an icon-only button with a per-project `aria-label`

## Verified

`pnpm typecheck` and `pnpm build` pass. Checked against the rendered page with live Prismic content: 3 cards, no `<article>` nesting, one `<main>` in the document, no `href=""`, and the three GitHub buttons get distinct accessible names.

Not included, per the discussion on the issue: cover image, tech tags, and the case-study link. Those need Prismic fields and #19.

## Also here

A second commit gitignores `AGENTS.md` and `CLAUDE.md`. Next 16 writes both at the repo root on dev server startup via `agentRules`, so they turn up as untracked files after running `pnpm dev`.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)
