### PR TITLE
fix: stop eslint from linting agent worktrees

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,7 @@ import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
 
 const config = [
   {
-    ignores: ["types.generated.ts"],
+    ignores: [".claude/**", "types.generated.ts"],
   },
   js.configs.recommended,
   ...nextCoreWebVitals,


### PR DESCRIPTION
`pnpm lint` fails on any checkout that has used Claude Code worktrees.

`.claude/worktrees/` holds full clones of the repo — sources, `node_modules`, build output — and `eslint .` walks all of it. On this machine that is ~14k errors across four worktrees, including duplicate `types.generated.ts` files and `cypress/` specs that the root config's ignore and globals blocks do not match, because those patterns are anchored at the repo root.

```
✖ 14054 problems (13924 errors, 130 warnings)
[ELIFECYCLE] Command failed with exit code 1
```

Adding `.claude/**` to the existing flat-config `ignores` fixes it. `pnpm lint` now exits 0 with no output.

No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)