### PR TITLE
feat: redesign blog cards and merge the two implementations

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -24,7 +24,7 @@ export default async function Index() {
         <H1>Blog</H1>
       </header>
 
-      <section className="mb-12 grid gap-6 sm:grid-cols-2">
+      <section className="mb-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {posts?.map((post) => (
           <PostPreview post={post} key={post?.id} />
         ))}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -24,7 +24,7 @@ export default async function Index() {
         <H1>Blog</H1>
       </header>
 
-      <section className="mb-12 grid gap-6 md:grid-cols-2 lg:gap-12">
+      <section className="mb-12 grid gap-6 sm:grid-cols-2">
         {posts?.map((post) => (
           <PostPreview post={post} key={post?.id} />
         ))}

--- a/src/components/IndexSlices/BlogPosts.tsx
+++ b/src/components/IndexSlices/BlogPosts.tsx
@@ -1,44 +1,15 @@
 import { BlogPostDocument } from "@/types.generated";
-import { PrismicImage, PrismicText } from "@prismicio/react";
-import Link from "next/link";
-import React from "react";
-import { Paragraph } from "../utils/text";
-
-const BlogPost = ({ data }: BlogPostDocument) => {
-  const { title, cover, slug, description } = data;
-  const blogHref = `/blog/${slug}`;
-
-  return (
-    <article>
-      <Link href={blogHref}>
-        <PrismicImage
-          field={cover}
-          fallbackAlt=""
-          className="mb-4 rounded-lg shadow-sm"
-        />
-      </Link>
-
-      <Link href={blogHref}>
-        <strong className="text-primary-800 hover:underline dark:text-primary-500">
-          <PrismicText field={title} />
-        </strong>
-      </Link>
-
-      <Paragraph size="small" className="mt-2">
-        <PrismicText field={description} />
-      </Paragraph>
-    </article>
-  );
-};
+import PostPreview from "../PostPreview";
+import { H2 } from "../utils/text";
 
 export default function BlogPosts({ posts }: { posts: BlogPostDocument[] }) {
   return (
     <section className="mx-auto max-w-[1080px] px-4 py-12">
-      <h2 className="mb-6 text-4xl font-bold tracking-tight">Latest Blogs</h2>
+      <H2 className="mb-6">Latest Blogs</H2>
 
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {posts.map((post) => (
-          <BlogPost key={post.id} {...post} />
+          <PostPreview key={post.id} post={post.data} />
         ))}
       </div>
     </section>

--- a/src/components/IndexSlices/Projects.tsx
+++ b/src/components/IndexSlices/Projects.tsx
@@ -1,10 +1,8 @@
 import { Content, asLink, asText } from "@prismicio/client";
 import { PrismicRichText, SliceComponentProps } from "@prismicio/react";
 import { GithubFill, LinkOut } from "akar-icons";
+import { FOCUS_RING } from "~/lib/focus-ring";
 import { H2, H3 } from "../utils/text";
-
-const FOCUS_RING =
-  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-50 dark:focus-visible:ring-primary-400 dark:focus-visible:ring-offset-gray-700";
 
 export default function Projects({
   slice,

--- a/src/components/PostPreview.tsx
+++ b/src/components/PostPreview.tsx
@@ -1,26 +1,11 @@
-import { Content } from "@prismicio/client";
+import { Content, isFilled } from "@prismicio/client";
 import { PrismicNextImage } from "@prismicio/next";
 import { PrismicText } from "@prismicio/react";
 import { ArrowRight } from "akar-icons";
-import Link, { LinkProps } from "next/link";
-import React from "react";
+import Link from "next/link";
+import { cn } from "~/lib/cn";
+import { FOCUS_RING } from "~/lib/focus-ring";
 import { H3, Paragraph } from "./utils/text";
-
-function LinkToPost({
-  children,
-  href,
-  ...rest
-}: {
-  children: React.ReactNode;
-  href: string;
-} & LinkProps &
-  React.AnchorHTMLAttributes<HTMLAnchorElement>) {
-  return (
-    <Link href={href} {...rest}>
-      {children}
-    </Link>
-  );
-}
 
 export default function PostPreview({
   post,
@@ -31,31 +16,47 @@ export default function PostPreview({
   const postHref = `/blog/${slug}`;
 
   return (
-    <div className="flex flex-col">
-      <LinkToPost href={postHref}>
-        <PrismicNextImage
-          field={cover}
-          className="mb-4 rounded-md shadow-sm"
-          alt=""
-        />
-      </LinkToPost>
+    <article className="flex flex-col rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-600 dark:bg-gray-700">
+      {isFilled.image(cover) && (
+        <Link
+          href={postHref}
+          tabIndex={-1}
+          aria-hidden
+          className="mb-4 block rounded-md"
+        >
+          <PrismicNextImage
+            field={cover}
+            alt=""
+            className="h-auto w-full rounded-md"
+          />
+        </Link>
+      )}
 
-      <LinkToPost href={postHref}>
-        <H3 className="text-primary-800 hover:underline dark:text-primary-500">
+      <H3>
+        <Link
+          href={postHref}
+          className={cn(
+            "rounded text-primary-800 hover:underline dark:text-primary-400",
+            FOCUS_RING
+          )}
+        >
           <PrismicText field={title} />
-        </H3>
-      </LinkToPost>
+        </Link>
+      </H3>
 
-      <Paragraph className="my-2">
+      <Paragraph className="mb-6 mt-2">
         <PrismicText field={description} />
       </Paragraph>
 
-      <LinkToPost
+      <Link
         href={postHref}
-        className="ml-auto mt-auto flex w-fit items-center gap-2 rounded-md px-6 py-2 font-semibold text-gray-500 transition-colors hover:bg-gray-800/30 hover:text-gray-900 dark:text-gray-500 dark:hover:bg-gray-200/30 dark:hover:text-gray-300"
+        className={cn(
+          "mt-auto flex w-fit items-center gap-2 rounded text-sm font-semibold text-primary-700 transition-colors hover:text-primary-800 dark:text-primary-300 dark:hover:text-primary-200",
+          FOCUS_RING
+        )}
       >
-        Read more <ArrowRight size={20} />
-      </LinkToPost>
-    </div>
+        Read more <ArrowRight size={18} />
+      </Link>
+    </article>
   );
 }

--- a/src/lib/focus-ring.ts
+++ b/src/lib/focus-ring.ts
@@ -1,0 +1,2 @@
+export const FOCUS_RING =
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-600 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-50 dark:focus-visible:ring-primary-400 dark:focus-visible:ring-offset-gray-700";


### PR DESCRIPTION
Closes #40

## Qué

Un solo `PostPreview` renderiza las tarjetas de blog en la home y en `/blog`. Se elimina el componente `BlogPost` duplicado dentro de `BlogPosts.tsx`.

## Por qué

Las dos implementaciones divergían (`<strong>` vs `<h3>`, `PrismicImage` vs `PrismicNextImage`, `<article>` vs `<div>`) y ninguna tenía contenedor, borde ni focus ring.

Bugs corregidos:

- Los títulos de la home eran `<strong>`, no encabezados: la sección quedaba sin outline para lectores de pantalla.
- Las portadas de la home usaban `PrismicImage` (`<img>` plano, sin `width`/`height` ni `loading="lazy"`) — ahora `PrismicNextImage` en ambas páginas.
- El `h2` de "Latest Blogs" era `text-4xl font-bold` hardcodeado, contra el primitivo `H2` que usa Projects justo encima.

## Cómo

- Tratamiento de tarjeta igual al de Projects (#18): `rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-600 dark:bg-gray-700`.
- `FOCUS_RING` se extrae a `src/lib/focus-ring.ts` y `Projects.tsx` lo importa, para que las dos tarjetas no vuelvan a divergir.
- Títulos a `primary-400` y "Read more" a `primary-300` en dark: sobre el fondo `gray-700` de la tarjeta, `primary-500` queda en 2.8:1, por debajo del mínimo de 3:1 para texto grande.
- El link de la portada queda `aria-hidden` + `tabIndex={-1}`: duplica el link del título, así que sigue siendo clickeable sin sumar un tercer tab stop por tarjeta.
- Mismo grid en ambas páginas: `sm:grid-cols-2 lg:grid-cols-3`. Se quita el `lg:gap-12` de `/blog`. Con 6 posts, `/blog` llena dos filas completas.
- `isFilled.image` evita renderizar un link vacío cuando el post no tiene portada.

## Verificación

`pnpm lint`, `pnpm typecheck` y `pnpm build` en verde. Revisado en el navegador contra el contenido real de Prismic en claro y oscuro: la home rinde tres `<h3>` bajo "Latest Blogs", las portadas salen con `loading="lazy"` y `1200x600`, y las filas de "Read more" alinean en ambos grids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
