### PR TITLE
fix: harden Prismic cache revalidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ prismicCodegen.config.ts
 
 # vercel
 .vercel
+
+# claude
+/.claude/

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -2,14 +2,20 @@ import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 export async function POST(req: Request) {
+  const secret = process.env.PRISMIC_WEBHOOK_SECRET;
+
+  if (!secret) {
+    return NextResponse.json(
+      { message: "Webhook secret not configured" },
+      { status: 500 }
+    );
+  }
+
   const body = (await req.json().catch(() => null)) as {
     secret?: string;
   } | null;
 
-  if (
-    process.env.PRISMIC_WEBHOOK_SECRET &&
-    body?.secret !== process.env.PRISMIC_WEBHOOK_SECRET
-  ) {
+  if (body?.secret !== secret) {
     return NextResponse.json({ message: "Invalid secret" }, { status: 401 });
   }
 

--- a/src/lib/prismic.ts
+++ b/src/lib/prismic.ts
@@ -7,7 +7,10 @@ export const prismicClient = (config: prismic.ClientConfig = {}) => {
   const client = prismic.createClient(apiEndpoint, {
     fetchOptions:
       process.env.NODE_ENV === "production"
-        ? { next: { tags: ["prismic"] }, cache: "force-cache" }
+        ? {
+            next: { tags: ["prismic"], revalidate: 3600 },
+            cache: "force-cache",
+          }
         : { next: { revalidate: 5 } },
     ...config,
   });


### PR DESCRIPTION
## What

- `src/lib/prismic.ts`: `revalidate: 3600` alongside the `prismic` tag, previously `force-cache` with no expiry.
- `src/app/api/revalidate/route.ts`: returns `500` when `PRISMIC_WEBHOOK_SECRET` is unset, instead of purging unauthenticated.
- `.gitignore`: ignores `/.claude/`, where the agent worktrees live.

## Why

Code blocks rendered unhighlighted in production even though #44 was already deployed. The served HTML carried the Shiki markup (`class="shiki"`, `--indent`) but zero colored spans: the Data Cache was returning a copy of the Prismic content from before the fence tags were added, so `parseFence` found no language and fell back to `text`. Vercel's Data Cache survives deployments, so redeploying never cleared it.

The purge never ran. The webhook pointed at the apex domain, the 308 to `www` turned Prismic's POST into a GET, and the route — which only exports `POST` — answered `405`. The URL is now fixed in Prismic; this change keeps the failure from being silent next time.

The previous guard only validated the secret when the variable was set, leaving the endpoint open to anyone if it ever disappeared from Vercel.

## How

- **Cache:** the TTL only caps staleness; the webhook still updates instantly on the happy path. It also covers the `/api/v2` call that resolves the master ref — a stale ref alone was enough to keep serving old content.
- **Endpoint:** deliberate tradeoff. If the variable goes missing, revalidation stops working (visible as `500` in Prismic's webhook log) rather than running unauthenticated.
- **Verified:** `tsc` and `eslint` clean on this base. All four endpoint paths tested against a real server: no secret `500`, correct secret `200`, wrong secret or no body `401`. `next build` reports no conflicting-cache-option warnings (`revalidate` only conflicts with `no-store`, not `force-cache`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
